### PR TITLE
Add support for RSA signing with PKCS-PSS padding scheme

### DIFF
--- a/src/signframework/cca_functions.h
+++ b/src/signframework/cca_functions.h
@@ -19,6 +19,11 @@
 
 #define CCA_KEY_IDENTIFIER_LENGTH 64	/* See CCA manual Key_Generate */
 
+enum SignMode {
+    SIGN_PKCS_1_1,   /* Incoming text must have been hashed and BER ASN.1 encoded */
+    SIGN_PKCS_PSS    /* Incoming text must have been hashed */
+};
+
 int Login_Control(int logIn,
 		   const char *userName,
 		   const char *password);
@@ -32,10 +37,19 @@ int Password_ToMechanism(unsigned char 	**mechanism,
 			 const char 	*password);
 
 int Key_Generate(unsigned char *generated_key_identifier_1);
+/*
+@brief Build a skeleton for an RSA bit size key
+@param token_length Length of resulting token
+@param token Buffer to store token
+@param bitSize RSA Key bit size (2048, 4096)
+@param encrypt If false restricts to a signing key
+@param useRsaAesc Use RSA-AESC token format instead of default RSA-CRT, RSA-AESC requred for RSA-PSS signing scheme
+*/
 int PKA_Key_Token_Build(long *token_length,
-			unsigned char *token,
-			unsigned int bitSize,
-			int encrypt);
+                        unsigned char *token,
+                        unsigned int bitSize,
+                        int encrypt,
+                        int useRsaAesc);
 int Random_Number_Generate_Long(unsigned char *random_number,
 				size_t random_number_length_in);
 int PKA_Decrypt(unsigned long *cleartext_length,
@@ -68,25 +82,27 @@ int PKA_Key_Generate(long *generated_key_identifier_length,
 		     long skeleton_key_token_length,
 		     unsigned char *skeleton_key_token);
 int Digital_Signature_Generate(unsigned long *signature_field_length,
-			       unsigned long *signature_bit_length,
-			       unsigned char *signature_field,
-			       unsigned long PKA_private_key_length,
-			       unsigned char *PKA_private_key,
-			       unsigned long hash_length,
-			       unsigned char *hash);
+                               unsigned long *signature_bit_length,
+                               unsigned char *signature_field,
+                               unsigned long PKA_private_key_length,
+                               unsigned char *PKA_private_key,
+                               unsigned long hash_length,
+                               unsigned char *hash,
+                               enum SignMode signmode);
 int Digital_Signature_Generate_Zero_Padding(unsigned long *signature_field_length,
-			       unsigned long *signature_bit_length,
-			       unsigned char *signature_field,
-			       unsigned long PKA_private_key_length,
-			       unsigned char *PKA_private_key,
-			       unsigned long hash_length,
-			       unsigned char *hash);
+                                            unsigned long *signature_bit_length,
+                                            unsigned char *signature_field,
+                                            unsigned long PKA_private_key_length,
+                                            unsigned char *PKA_private_key,
+                                            unsigned long hash_length,
+                                            unsigned char *hash);
 int Digital_Signature_Verify(unsigned long signature_field_length,
-			     unsigned char *signature_field,
-			     unsigned long key_token_length,
-			     unsigned char *key_token,
-			     unsigned long hash_length,
-			     unsigned char *hash);
+                             unsigned char *signature_field,
+                             unsigned long key_token_length,
+                             unsigned char *key_token,
+                             unsigned long hash_length,
+                             unsigned char *hash,
+                             enum SignMode signmode);
 int Digital_Signature_Verify_Zero_Padding(unsigned long signature_field_length,
 			     					      unsigned char *signature_field,
 			     					      unsigned long key_token_length,

--- a/src/signframework/cca_structures.h
+++ b/src/signframework/cca_structures.h
@@ -27,6 +27,8 @@
 #define RSA_PRIVATE_KEY_2048_CRT_DEP	0x05	/* deprecated */
 #define RSA_PRIVATE_KEY_1024_INTERNAL	0x06
 #define RSA_PRIVATE_KEY_CRT		0x08
+#define RSA_PRIVATE_KEY_MODEXP_AES_OPK 0x30
+#define RSA_PRIVATE_KEY_CRT_AES_OPK 0x31
 
 /* keyFormat */
 #define RSA_EXTERNAL_UNENCRYPTED	0x40
@@ -131,6 +133,11 @@ long parsePKA96KeyTokenPrivateKey(RsaKeyTokenPublic *rsaKeyTokenPublic,
                                   long *keyTokenLength,
                                   unsigned char **keyToken,
                                   unsigned int bitSize);
+long parsePKA96KeyTokenPrivateKeyAesOPK(RsaKeyTokenPublic *rsaKeyTokenPublic,
+                                        RsaKeyTokenPrivate *rsaKeyTokenPrivate,
+                                        long *keyTokenLength,
+                                        unsigned char **keyToken,
+                                        unsigned int bitSize);
 
 /*
   Debug Print Functions

--- a/src/signframework/framework_test.c
+++ b/src/signframework/framework_test.c
@@ -415,7 +415,8 @@ int SignSampleRSA(unsigned char 	*keyToken,
                                             keyTokenLength,		/* input */
                                             keyToken,			/* input */
                                             hashLength,			/* input */
-                                            hash);			/* input */
+                                            hash,               /* input */
+                                            SIGN_PKCS_1_1);     /* input */
 
         }
         /* sample  - create the audit log entry */
@@ -456,7 +457,8 @@ int SignSampleRSA(unsigned char 	*keyToken,
                                           keyTokenLength,		/* input */
                                           keyToken,			/* input key */
                                           hashLength,			/* input */
-                                          hash);			/* input hash */
+                                          hash,			/* input hash */
+                                          SIGN_PKCS_1_1);
         }
         /* sample code to verify the signature using openssl */
         if (rc == 0) {

--- a/src/signframework/framework_utils.h
+++ b/src/signframework/framework_utils.h
@@ -63,6 +63,7 @@ typedef struct tdProjectConfig {
     char        **senderemails; /* array of associated sender email addresses */
     size_t		notificationListCount;	/* number of notification receivers */
     char		**notificationList;	/* array of notification names */
+    Arguments   additionalArgs;     /* Additional sign tool arguments specified in project config */
 } ProjectConfig;
 
 /// Status/configuration information for a dropbox

--- a/src/signframework/keygen.c
+++ b/src/signframework/keygen.c
@@ -34,6 +34,7 @@ long getArgs(const char **keyFilename,
              const char **password,
              unsigned int *bitSize,
              int *encrypt,
+             int *rsaaesc,
              int *verbose,
              int argc,
              char ** argv);
@@ -60,6 +61,7 @@ int main(int argc, char** argv)
     const char 	*password;		/* optional user password */
     unsigned int bitSize = 2048;	/* default RSA key size */
     int encrypt = FALSE;		/* default is signing key */
+    int rsaaesc = FALSE;        /* default is RSA-CRT format token */
 
     /* skeleton CCA key token, template parameters for the eventual generated key pair */
     long          	skeleton_key_length;
@@ -80,7 +82,7 @@ int main(int argc, char** argv)
     if (rc == 0) {
         rc = getArgs(&keyFilename, &pubKeyFilename,
                      &userName, &password, &bitSize, &encrypt,
-                     &verbose, argc, argv);
+                     &rsaaesc, &verbose, argc, argv);
     }
     /*
       Log in
@@ -96,7 +98,7 @@ int main(int argc, char** argv)
     /* build a skeleton key token */
     if (rc == 0) {
         skeleton_key_length = sizeof(skeleton_key);
-        rc = PKA_Key_Token_Build(&skeleton_key_length, skeleton_key, bitSize, encrypt);
+        rc = PKA_Key_Token_Build(&skeleton_key_length, skeleton_key, bitSize, encrypt, rsaaesc);
     }
     /* generate an RSA key pair using the skeleton key token */
     if (rc == 0) {
@@ -140,7 +142,7 @@ int main(int argc, char** argv)
         return EXIT_SUCCESS;
     }
     else {
-        printf("keygen: Failure\n");
+        printf("keygen: Failure : %d\n", (int)rc);
         return EXIT_FAILURE;
     }
 }
@@ -155,6 +157,7 @@ long getArgs(const char **keyFilename,
              const char **password,
              unsigned int *bitSize,
              int *encrypt,
+             int *rsaaesc,
              int *verbose,
              int argc,
              char **argv)
@@ -170,6 +173,7 @@ long getArgs(const char **keyFilename,
     *userName = NULL;
     *password = NULL;
     *verbose = FALSE;
+    *rsaaesc = FALSE;
 
     /* get the command line arguments */
     for (i=1 ; (i<argc) && (rc == 0) ; i++) {
@@ -221,6 +225,9 @@ long getArgs(const char **keyFilename,
         }
         else if (strcmp(argv[i],"-enc") == 0) {
             *encrypt = TRUE;
+        }
+        else if (strcmp(argv[i],"-aesc") == 0) {
+            *rsaaesc = TRUE;
         }
         else if (strcmp(argv[i],"-h") == 0) {
             printUsage();
@@ -281,6 +288,7 @@ void printUsage()
     printf("\t-u user name and password\n");
     printf("\t-sz bit size (default 2048)\n");
     printf("\t-enc (can be used as a encryption key, default signing only)\n");
+    printf("\t-aesc Format as an RSA-AESC token, required for RSA-PSS signing (default RSA-CRT)\n");
     printf("\t-h help\n");
     printf("\t-v enable debug tracing\n");
     printf("\n");

--- a/src/signframework/makefile
+++ b/src/signframework/makefile
@@ -31,6 +31,9 @@ LNFLAGS =  -ggdb -lcrypto -lcsulcca -ljson-c
 
 all:    framework framework_test frameworkkey_generate keygen password_generate password_change \
 		keygeneccp521 audit sender_validate audit_archive getpubkey getpubkeyecc setclock
+	(cd sign_sha512 && make)
+	(cd signecc && make)
+	(cd sign_rsa_raw && make)
 #all:		ccatest  
 #		signature_verify \
 #		audit_archive t

--- a/src/signframework/sign_sha384/sign_sha384.c
+++ b/src/signframework/sign_sha384/sign_sha384.c
@@ -272,7 +272,8 @@ int Sign(const char 	*keyFileName,
                                         keyTokenLength,			/* input */
                                         keyToken,			/* input */
                                         sizeof(sha384_rsa_oid) + SHA384_SIZE, /* input */
-                                        hash384);			/* input */
+                                        hash384,            /* input */
+                                        SIGN_PKCS_1_1);     /* input */
 
     }
     /* create the audit log entry */


### PR DESCRIPTION
- The sign_sha512 signer supports PKCS-PSS padding scheme
  To enable add -rsassa-pss option to signing requests.  The key
  tokens must be built with the 'keygen -aesc' as well

- Also add support for project config file to define sign tool parms
  Sign tool parameters can be provided on the 'program' line in the
  sign tool configuration file.  These parameters will be added during
  all signing requests