### PR TITLE
Match the default key size between keygen and rsa signing operations

### DIFF
--- a/src/signframework/keygen.c
+++ b/src/signframework/keygen.c
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     const char	*pubKeyFilename;	/* destination file for the generated public key */
     const char	*userName;		/* optional user name */
     const char 	*password;		/* optional user password */
-    unsigned int bitSize = 2048;	/* default RSA key size */
+    unsigned int bitSize = 4096;	/* default RSA key size */
     int encrypt = FALSE;		/* default is signing key */
     int rsaaesc = FALSE;        /* default is RSA-CRT format token */
 
@@ -275,7 +275,7 @@ void printUsage()
     printf("\n");
     printf("Example: keygen -k key.tok -p pub.bin -u user password \n");
     printf("\n");
-    printf("Generates an RSA 2048-bit signing key token using CCA, and stores the\n"
+    printf("Generates an RSA 4096-bit signing key token using CCA, and stores the\n"
            "resulting key pair token in the key token file.  The public key modulus\n"
            "n is stored in binary in the public key token file.\n"
            "\n"
@@ -286,7 +286,7 @@ void printUsage()
     printf("\t-k key token file name\n");
     printf("\t-p public key modulus file name\n");
     printf("\t-u user name and password\n");
-    printf("\t-sz bit size (default 2048)\n");
+    printf("\t-sz bit size (default 4096)\n");
     printf("\t-enc (can be used as a encryption key, default signing only)\n");
     printf("\t-aesc Format as an RSA-AESC token, required for RSA-PSS signing (default RSA-CRT)\n");
     printf("\t-h help\n");

--- a/src/signframework/pullkeys
+++ b/src/signframework/pullkeys
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Copyright 2021 IBM Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "$1" = "" ]; then
+  echo "Syntax: pullkeys <signframework-cfg base dir>"
+  exit 1;
+fi
+
+BASEDIR=$1
+
+if [ ! -e "$BASEDIR/keys/masterkey.bin" ]; then
+   echo "ERROR : $BASEDIR doesn't appear to have keys"
+   exit 1;
+fi
+
+if [ ! -e "$PWD/framework.c" ]; then
+   echo "ERROR : pullkeys must be run from framework directory"
+   exit 1;
+fi
+
+cp -r $BASEDIR/keys/* .


### PR DESCRIPTION
Default key size for keygen was 2048, now it is 4096.
Default key size for RSA signing is 4096

Also adds a script to make it easier to import keys onto a server.