### PR TITLE
client: build: support for meson

### DIFF
--- a/src/client/meson.build
+++ b/src/client/meson.build
@@ -1,0 +1,43 @@
+project(
+    'sb-signing-framwork',
+    'c',
+    default_options: [
+        'c_std=gnu99',
+        'werror=true',
+        'warning_level=3',
+    ],
+    version: '1.0'
+)
+
+cc = meson.get_compiler('c')
+
+executable(
+    'sf_client',
+    'client.c',
+    'pscp_json.c',
+    'pscp_sftp.c',
+    c_args: [
+        '-Wno-unused-parameter',
+        '-Wno-sign-compare',
+    ],
+    dependencies: [
+        dependency('json-c'),
+        dependency('libcrypto'),
+        dependency('libcurl'),
+        dependency('libssl'),
+        cc.find_library('m'),
+    ],
+    install: true
+)
+
+executable(
+    'sftp-test',
+    'pscp_sftp_test.c',
+    'pscp_sftp.c',
+    c_args: [
+        '-Wno-unused-parameter',
+    ],
+    dependencies: [
+        dependency('libcurl'),
+    ]
+)


### PR DESCRIPTION
Support building the client with meson.

meson is a modern, fast and easy to use build system similar to cmake.

to build:
  meson build && ninja -C build

to install:
  ninja -C build install

in one step:
  meson build && ninja -C build install

to install to an alternate prefix (default is /usr/local):
  meson -Dprefix=~/.local build && ninja -C build install

Support mostly mirrors the existing makefile with a couple exceptions:

- sftp-test is not installed (it is built by default; however).  As a
  developer tool it is unexpected to find it in the install target, so
  do not install it under meson.

- unnecessary links and sources are removed from the test application
  under meson