### PR TITLE
Add a PKCS11 module that wraps sf_client functionality

### DIFF
--- a/src/client-c++/.clang-format
+++ b/src/client-c++/.clang-format
@@ -1,0 +1,111 @@
+---
+# Documentation:
+# https://releases.llvm.org/7.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+
+# The main header for a source has priority 0
+IncludeCategories:
+  - Regex:           '^[<"]HvPlicModule'
+    Priority:        -4
+  - Regex:           '^<'
+    Priority:        -3
+  - Regex:           '^"'
+    Priority:        -1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 302
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 1
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        4
+UseTab:          Never
+...

--- a/src/client-c++/.gitignore
+++ b/src/client-c++/.gitignore
@@ -1,0 +1,2 @@
+build
+scratch

--- a/src/client-c++/.vscode/c_cpp_properties.json
+++ b/src/client-c++/.vscode/c_cpp_properties.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "linux-clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/src/client-c++/.vscode/settings.json
+++ b/src/client-c++/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+        "editor.formatOnSave": true,
+        "editor.formatOnSaveMode": "file",
+        "editor.tabSize": 4,
+        "editor.useTabStops": false,
+        "files.associations": {
+                "*.cpp": "cpp",
+        },
+        "C_Cpp.errorSquiggles": "Disabled"
+}

--- a/src/client-c++/.vscode/tasks.json
+++ b/src/client-c++/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+        // See https://go.microsoft.com/fwlink/?LinkId=733558
+        // for the documentation about the tasks.json format
+        "version": "2.0.0",
+        "tasks": [
+                {
+                        "label": "Ninja Build",
+                        "type": "shell",
+                        "command": "ninja",
+                        "args": [
+                                "-C",
+                                "build"
+                        ],
+                        "group": {
+                                "kind": "build",
+                                "isDefault": true
+                        },
+                        "presentation": {
+                                "reveal": "always"
+                        },
+                        "problemMatcher": "$gcc"
+                }
+        ]
+}

--- a/src/client-c++/README.md
+++ b/src/client-c++/README.md
@@ -1,0 +1,28 @@
+# Dependencies
+
+- meson
+- g++/clang++
+- cmake
+- json-c
+- openssl
+- curl
+
+# Compile
+
+Only building sf_client:
+```
+meson build -Dlib-pkcs11=false
+ninja -C build
+```
+
+Building sf_client and the pkcs11 shared library module:
+```
+meson build -Dlib-pkcs11=true
+ninja -C build
+```
+
+# Install
+
+```
+meson install
+```

--- a/src/client-c++/cli_main.cpp
+++ b/src/client-c++/cli_main.cpp
@@ -29,7 +29,7 @@
 
 enum OptOptions
 {
-    // Requried Args (must be grouped first for dynamic help text)
+    // Required Args (must be grouped first for dynamic help text)
     Project,
     Comment,
     Epwd,
@@ -271,8 +271,6 @@ int main(int argc, char** argv)
     {
         Verbose_PrintArgs(sArgs);
     }
-
-    sIsSuccess = true;
 
     if(!sIsSuccess)
     {

--- a/src/client-c++/cli_main.cpp
+++ b/src/client-c++/cli_main.cpp
@@ -60,7 +60,7 @@ struct option create_long_options[NumOptOptions + 1] =
 {
     // Required
     {"project",  required_argument, NULL, 'p'},
-    {"comment",  required_argument, NULL, 'c'},
+    {"comments", required_argument, NULL, 'c'},
     {"epwd",     required_argument, NULL, 'e'},
     {"url",      required_argument, NULL, 'u'},
     {"pkey",     required_argument, NULL, 'k'},

--- a/src/client-c++/cli_main.cpp
+++ b/src/client-c++/cli_main.cpp
@@ -143,7 +143,7 @@ bool ParseArgs(const int argcParm, char** argvParm, SfClientArgs& argsParm)
 
         if(-1 == sOption)
         {
-            return false;
+            break;
         }
         else if(sOption == create_long_options[Project].val)
         {
@@ -200,7 +200,8 @@ bool ParseArgs(const int argcParm, char** argvParm, SfClientArgs& argsParm)
             argsParm.mDebug = true;
         }
     }
-    return sNumRequiredArgsFound == NumRequiredArgs;
+
+    return true;
 }
 
 void PrintHelp(const std::string& programNameParm)
@@ -372,6 +373,10 @@ int main(int argc, char** argv)
             }
         }
         sIsSuccess = sf_client::success == sRc;
+        if(!sIsSuccess)
+        {
+            std::cout << "Unable to connect to server, rc = " << sRc << std::endl;
+        }
     }
 
     if(sIsSuccess)

--- a/src/client-c++/cli_main.cpp
+++ b/src/client-c++/cli_main.cpp
@@ -1,0 +1,410 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <csignal>
+#include <cstdio>
+#include <cstring> // strlen
+#include <fstream>
+#include <getopt.h>
+#include <iostream>
+#include <openssl/crypto.h> // Used for OpenSSL_malloc
+#include <sf_utils/sf_utils.h>
+#include <string>
+#include <termios.h>
+#include <vector>
+
+#include <sf_client/sf_client.h>
+
+enum OptOptions
+{
+    // Requried Args (must be grouped first for dynamic help text)
+    Project,
+    Comment,
+    Epwd,
+    Url,
+    PrivateKey,
+    Payload,
+
+    // Optional Args
+    PasswordEnvVar,
+    Param,
+    Output,
+    ServerStdOut,
+    Verbose,
+    Debug,
+
+    NumOptOptions
+};
+
+enum
+{
+    NumRequiredArgs     = 6,
+    MaxPasswordSize     = 1024,
+    MaxPasswordAttempts = 3,
+};
+
+// clang-format off
+struct option create_long_options[NumOptOptions + 1] =
+{
+    // Required
+    {"project",  required_argument, NULL, 'p'},
+    {"comment",  required_argument, NULL, 'c'},
+    {"epwd",     required_argument, NULL, 'e'},
+    {"url",      required_argument, NULL, 'u'},
+    {"pkey",     required_argument, NULL, 'k'},
+    {"payload",  required_argument, NULL, 'i'},
+    // Optional
+    {"password", required_argument, NULL, 'a'},
+    {"param",    required_argument, NULL, 'r'},
+    {"output",   required_argument, NULL, 'o'},
+    {"stdout",   no_argument,       NULL, 's'},
+    {"verbose",  no_argument,       NULL, 'v'},
+    {"debug",    no_argument,       NULL, 'd'},
+    {0, 0, 0, 0}
+};
+
+const std::string OptOptionsHelpText[NumOptOptions] =
+{
+    // Required
+    "Name of the project",
+    "Identifier/Message for audit log",
+    "File path to the hsm encrypted password",
+    "sftp url. Example: sftp://user@address",
+    "File path to the *encrypted* private key file",
+    "File path to the binary to be signed",
+    // Optional
+    "Environment variable to read the password from",
+    "Parameters to be passed to the signing framework. Ex '-v' or '-h'",
+    "output file to save the return payload",
+    "Displays the stdout from the server",
+    "verbose tracing",
+    "debug mode - files will not be deleted"
+};
+// clang-format on
+
+struct SfClientArgs
+{
+    SfClientArgs()
+    : mServerStdOut(false)
+    , mVerbose(false)
+    , mDebug(false)
+    {
+    }
+    std::string mProject;
+    std::string mComment;
+    std::string mEpwdPath;
+    std::string mUrl;
+    std::string mPrivateKeyPath;
+    std::string mPayloadPath;
+    std::string mExtraServerParms;
+    std::string mOutputPath;
+    std::string mPasswordEnvVar;
+    bool        mServerStdOut;
+    bool        mVerbose;
+    bool        mDebug;
+};
+
+bool ParseArgs(const int argcParm, char** argvParm, SfClientArgs& argsParm)
+{
+    std::string sShortOptions = "";
+
+    for(std::size_t sIdx = 0; sIdx < NumOptOptions; sIdx++)
+    {
+        sShortOptions += create_long_options[sIdx].val;
+        if(required_argument == create_long_options[sIdx].has_arg)
+        {
+            sShortOptions += ":";
+        }
+    }
+
+    int sOption;
+    int sNumRequiredArgsFound = 0;
+    while(1)
+    {
+        int sOptionIndex = 0;
+
+        // Use getopt_long_only to enable long options using only a single dash (i.e. -project).
+        // This allows scripts using the old sf_client (in C) to use this version without having to
+        // be rewritten.
+        sOption = getopt_long_only(
+            argcParm, argvParm, sShortOptions.c_str(), create_long_options, &sOptionIndex);
+
+        if(-1 == sOption)
+        {
+            return false;
+        }
+        else if(sOption == create_long_options[Project].val)
+        {
+            sNumRequiredArgsFound++;
+            argsParm.mProject = optarg;
+        }
+        else if(sOption == create_long_options[Comment].val)
+        {
+            sNumRequiredArgsFound++;
+            argsParm.mComment = optarg;
+        }
+        else if(sOption == create_long_options[Epwd].val)
+        {
+            sNumRequiredArgsFound++;
+            argsParm.mEpwdPath = optarg;
+        }
+        else if(sOption == create_long_options[Url].val)
+        {
+            sNumRequiredArgsFound++;
+            argsParm.mUrl = optarg;
+        }
+        else if(sOption == create_long_options[PrivateKey].val)
+        {
+            sNumRequiredArgsFound++;
+            argsParm.mPrivateKeyPath = optarg;
+        }
+        else if(sOption == create_long_options[Payload].val)
+        {
+            sNumRequiredArgsFound++;
+            argsParm.mPayloadPath = optarg;
+        }
+        else if(sOption == create_long_options[PasswordEnvVar].val)
+        {
+            argsParm.mPasswordEnvVar = optarg;
+        }
+        else if(sOption == create_long_options[Param].val)
+        {
+            argsParm.mExtraServerParms = optarg;
+        }
+        else if(sOption == create_long_options[Output].val)
+        {
+            argsParm.mOutputPath = optarg;
+        }
+        else if(sOption == create_long_options[ServerStdOut].val)
+        {
+            argsParm.mServerStdOut = true;
+        }
+        else if(sOption == create_long_options[Verbose].val)
+        {
+            argsParm.mVerbose = true;
+        }
+        else if(sOption == create_long_options[Debug].val)
+        {
+            argsParm.mDebug = true;
+        }
+    }
+    return sNumRequiredArgsFound == NumRequiredArgs;
+}
+
+void PrintHelp(const std::string& programNameParm)
+{
+    std::size_t sLongestOption = 0;
+    for(std::size_t sIdx = 0; sIdx < NumOptOptions; sIdx++)
+    {
+        std::size_t sLength = strlen(create_long_options[sIdx].name);
+        sLongestOption      = std::max(sLength, sLongestOption);
+    }
+
+    std::cout << "Usage: " << programNameParm << std::endl;
+    std::cout << "Required:" << std::endl;
+    for(std::size_t sIdx = 0; sIdx < NumOptOptions; sIdx++)
+    {
+        // Assumes that the required args always are grouped first in the list
+        if(NumRequiredArgs == sIdx)
+        {
+            std::cout << std::endl << "Optional:" << std::endl;
+        }
+        std::size_t sCurrentOptionLength = strlen(create_long_options[sIdx].name);
+        std::cout << "\t-" << (char)create_long_options[sIdx].val << " -"
+                  << create_long_options[sIdx].name;
+        for(std::size_t sPadIdx = 0; sPadIdx < (sLongestOption - sCurrentOptionLength); sPadIdx++)
+        {
+            std::cout << " ";
+        }
+        std::cout << " --" << create_long_options[sIdx].name;
+        for(std::size_t sPadIdx = 0; sPadIdx < (sLongestOption - sCurrentOptionLength); sPadIdx++)
+        {
+            std::cout << " ";
+        }
+        std::cout << " | " << OptOptionsHelpText[sIdx] << std::endl;
+    }
+}
+
+void Verbose_PrintArgs(const SfClientArgs& argsParm)
+{
+    std::cout << "Project:            " << argsParm.mProject << std::endl;
+    std::cout << "Comment:            " << argsParm.mComment << std::endl;
+    std::cout << "Epwd Path:          " << argsParm.mEpwdPath << std::endl;
+    std::cout << "URL:                " << argsParm.mUrl << std::endl;
+    std::cout << "Private Key Path:   " << argsParm.mPrivateKeyPath << std::endl;
+    std::cout << "Payload Path:       " << argsParm.mPayloadPath << std::endl;
+    std::cout << "Extra Server Parms: " << argsParm.mExtraServerParms << std::endl;
+    std::cout << "Output Path:        " << argsParm.mOutputPath << std::endl;
+    std::cout << "Password ENV:        " << argsParm.mPasswordEnvVar << std::endl;
+    std::cout << std::endl;
+    std::cout << "StdOut:   " << (argsParm.mServerStdOut ? "true" : "false") << std::endl;
+    std::cout << "Verbose:  " << (argsParm.mVerbose ? "true" : "false") << std::endl;
+    std::cout << "Debug:    " << (argsParm.mDebug ? "true" : "false") << std::endl;
+}
+
+int main(int argc, char** argv)
+{
+    std::string sProgramName = argv[0];
+    bool        sIsSuccess   = true;
+
+    sf_client::ServerInfoV1      sSfServerV1;
+    sf_client::CommandArgsV1     sSfArgsV1;
+    sf_client::CommandResponseV1 sSfResponseV1;
+    sf_client::Session           sSession;
+
+    SfClientArgs sArgs;
+    sIsSuccess = ParseArgs(argc, argv, sArgs);
+
+    if(sArgs.mVerbose)
+    {
+        Verbose_PrintArgs(sArgs);
+    }
+
+    sIsSuccess = true;
+
+    if(!sIsSuccess)
+    {
+        PrintHelp(sProgramName);
+        return -1; // Early return for simplicity
+    }
+
+    if(sIsSuccess && !sArgs.mPayloadPath.empty())
+    {
+        sIsSuccess = ReadFile(sArgs.mPayloadPath, sSfArgsV1.mPayload);
+    }
+
+    // Make life easier: if the project is "password_change" turn on stdout automatically.
+    // Otherwise the password will be changed but the result will not be presented to the
+    // caller.
+    if(sIsSuccess && sArgs.mProject == std::string("password_change"))
+    {
+        sArgs.mServerStdOut = true;
+        std::cout << "Set std out true" << std::endl;
+    }
+
+    if(sIsSuccess)
+    {
+        sSfServerV1.mPrivateKeyPath = sArgs.mPrivateKeyPath;
+        sSfServerV1.mUrl            = sArgs.mUrl;
+        sSfServerV1.mEpwdPath       = sArgs.mEpwdPath;
+        sSfServerV1.mCurlDebug      = sArgs.mDebug;
+        sSfServerV1.mVerbose        = sArgs.mVerbose;
+
+        sSfArgsV1.mProject          = sArgs.mProject;
+        sSfArgsV1.mComment          = sArgs.mComment;
+        sSfArgsV1.mExtraServerParms = sArgs.mExtraServerParms;
+    }
+
+    if(sIsSuccess && !sArgs.mPasswordEnvVar.empty())
+    {
+        std::cout << "Running with ENV" << std::endl;
+        sSfServerV1.mPasswordPtr = getenv(sArgs.mPasswordEnvVar.c_str());
+        sf_client::rc sRc        = sf_client::connectToServer(sSfServerV1, sSession);
+        sIsSuccess               = sf_client::success == sRc;
+        // The password was provided in the environment. If it is wrong there is nothing else to be
+        // done.
+    }
+    else if(sIsSuccess)
+    {
+        std::cout << "Attempt running with agent" << std::endl;
+        // Attempt a connection without providing a password. If the key is registered in an agent
+        // then the connection will work without needing user interaction.
+        sSfServerV1.mPasswordPtr = NULL;
+        sf_client::rc sRc        = sf_client::connectToServer(sSfServerV1, sSession);
+        std::cout << sRc << std::endl;
+
+        if(sf_client::success != sRc)
+        {
+            std::cout << "Running with prompt" << std::endl;
+            sRc = sf_client::success;
+
+            char* sPasswordPtr = (char*)OPENSSL_malloc(MaxPasswordSize);
+            if(sPasswordPtr)
+                memset(sPasswordPtr, 0, MaxPasswordSize);
+
+            if(!sPasswordPtr)
+            {
+                std::cerr << "Unable to allocate memory for password buffer" << std::endl;
+                sIsSuccess = false;
+            }
+            else
+            {
+                std::size_t sNumAttempts = 0;
+                do
+                {
+                    sNumAttempts++;
+
+                    std::size_t sPasswordLength = 0;
+
+                    const bool sResult = GetPassword(
+                        sPasswordPtr, MaxPasswordSize, sPasswordLength, sArgs.mVerbose);
+
+                    if(sArgs.mVerbose)
+                    {
+                        std::cout << "GetPassword Result: " << (sResult ? "true" : "false")
+                                  << std::endl;
+                    }
+
+                    if(sResult)
+                    {
+                        sSfServerV1.mPasswordPtr = sPasswordPtr;
+                        sRc = sf_client::connectToServer(sSfServerV1, sSession);
+                    }
+
+                    if(sArgs.mVerbose)
+                    {
+                        std::cout << "Finishing Attempt #" << sNumAttempts << std::endl;
+                    }
+                } while(sf_client::password_retry == sRc && sNumAttempts < MaxPasswordAttempts);
+
+                memset(sPasswordPtr, 0, MaxPasswordSize);
+                OPENSSL_free(sPasswordPtr);
+            }
+        }
+        sIsSuccess = sf_client::success == sRc;
+    }
+
+    if(sIsSuccess)
+    {
+        sf_client::rc sRc = sf_client::sendCommandV1(sSession, sSfArgsV1, sSfResponseV1);
+        sIsSuccess        = sf_client::success == sRc;
+    }
+
+    if(sIsSuccess)
+    {
+        if(sArgs.mServerStdOut)
+        {
+            std::cout << std::endl;
+            std::cout << "==== Begin Standard Out ====" << std::endl;
+            std::cout << std::endl;
+            std::cout << sSfResponseV1.mStdOut << std::endl;
+            std::cout << "==== End of Standard Out ====" << std::endl;
+        }
+
+        if(0 != sSfResponseV1.mReturnCode)
+        {
+            std::cerr << "Signing server responded with failure: " << sSfResponseV1.mReturnCode
+                      << std::endl
+                      << "Rerun with -stdout to see server output" << std::endl;
+        }
+
+        if(!sArgs.mOutputPath.empty())
+        {
+            sIsSuccess = WriteFile(sArgs.mOutputPath, sSfResponseV1.mOutput);
+        }
+    }
+
+    return sIsSuccess ? 0 : -1;
+}

--- a/src/client-c++/meson.build
+++ b/src/client-c++/meson.build
@@ -1,0 +1,24 @@
+project(
+    'client-c++',
+    'cpp',
+    default_options: [
+        'werror=true',
+        'warning_level=3',
+    ],
+    version: '1.0'
+)
+
+cc = meson.get_compiler('cpp')
+
+subdir('sf_utils')
+subdir('sf_client_lib')
+subdir('sf_pkcs11')
+
+executable(
+    'sf_client',
+    'cli_main.cpp',
+    dependencies: [
+        sf_client_dep
+    ],
+    install: true
+)

--- a/src/client-c++/meson_options.txt
+++ b/src/client-c++/meson_options.txt
@@ -1,0 +1,2 @@
+
+option('lib-pkcs11', type : 'boolean', value : false)

--- a/src/client-c++/sf_client_lib/include/sf_client/sf_client.h
+++ b/src/client-c++/sf_client_lib/include/sf_client/sf_client.h
@@ -1,0 +1,66 @@
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include <sf_client/sf_rc.h>
+
+#ifndef _SFCLIENT_H
+#define _SFCLIENT_H
+
+namespace sf_client
+{
+    class Curl_Session;
+
+    struct CommandArgsV1
+    {
+        CommandArgsV1()
+        : mPasswordPtr(NULL)
+        {
+        }
+        std::string          mProject;
+        std::string          mComment;
+        std::string          mExtraServerParms;
+        std::vector<uint8_t> mPayload;
+        char*                mPasswordPtr; // c_str (null-terminated)
+    };
+
+    struct CommandResponseV1
+    {
+        std::vector<uint8_t> mOutput;
+        std::string          mStdOut;
+        int                  mReturnCode;
+    };
+
+    struct ServerInfoV1
+    {
+        ServerInfoV1()
+        : mVerbose(false)
+        , mCurlDebug(false)
+        {
+        }
+        std::string mUrl;
+        std::string mPrivateKeyPath;
+        std::string mEpwdPath;
+        const char* mPasswordPtr;
+        bool        mVerbose;
+        bool        mCurlDebug;
+    };
+
+    struct Session
+    {
+        Session();
+        ~Session();
+
+        Curl_Session* mCurlSession;
+    };
+
+    rc connectToServer(const ServerInfoV1& serverParm, Session& sessionParm);
+
+    rc disconnect(Session& sessionParm);
+
+    rc sendCommandV1(Session&             sessionParm,
+                     const CommandArgsV1& argsParm,
+                     CommandResponseV1&   responseParm);
+} // namespace sf_client
+
+#endif

--- a/src/client-c++/sf_client_lib/include/sf_client/sf_rc.h
+++ b/src/client-c++/sf_client_lib/include/sf_client/sf_rc.h
@@ -1,0 +1,27 @@
+
+#ifndef _SFRC_H
+#define _SFRC_H
+
+namespace sf_client
+{
+    enum rc
+    {
+        success                     = 0,
+        failure                     = 1,
+        invalid_parm                = 2,
+        password_retry              = 3,
+        pkey_not_encrypted          = 4,
+        json_new_obj_fail           = 5,
+        json_convert_to_string_fail = 6,
+        json_invalid_parm           = 7,
+        json_invalid_object_type    = 8,
+        json_tag_not_found          = 9,
+        json_parse_root_fail        = 10,
+        epwd_read_fail              = 11,
+        curl_failure                = 12,
+        curl_init_failure           = 13,
+    };
+
+}
+
+#endif

--- a/src/client-c++/sf_client_lib/meson.build
+++ b/src/client-c++/sf_client_lib/meson.build
@@ -1,0 +1,24 @@
+cc = meson.get_compiler('cpp')
+
+sf_client_deps = [
+    dependency('json-c'),
+    dependency('libcrypto'),
+    dependency('libcurl'),
+    dependency('libssl'),
+    sf_utils_dep
+]
+
+lib_sf_client = static_library(
+    'sf_client',
+    'sf_client.cpp',
+    'sf_curl.cpp',
+    'sf_json.cpp',
+    include_directories : 'include',
+    dependencies: sf_client_deps
+)
+
+sf_client_dep = declare_dependency(
+    dependencies: sf_client_deps,
+    include_directories: 'include',
+    link_with: lib_sf_client
+)

--- a/src/client-c++/sf_client_lib/sf_client.cpp
+++ b/src/client-c++/sf_client_lib/sf_client.cpp
@@ -1,0 +1,176 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+#include <sf_client/sf_client.h>
+#include <sf_utils/sf_utils.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sf_curl.h"
+#include "sf_json.h"
+
+sf_client::Session::Session() { mCurlSession = new Curl_Session(); }
+
+sf_client::Session::~Session() { delete mCurlSession; }
+
+bool PrivateKeyEncrypted(const std::string& keyPathParm)
+{
+    bool  encrypted = false;
+    FILE* key       = fopen(keyPathParm.c_str(), "r");
+    if(key)
+    {
+        fseek(key, 0, SEEK_END);
+        int len = ftell(key);
+        rewind(key);
+
+        char* privKey = (char*)calloc(len + 1, 1);
+        if(privKey)
+        {
+            int read_len = fread(privKey, 1, len, key);
+
+            if(read_len == len)
+            {
+                char* location = strstr(privKey, "ENCRYPTED");
+                if(location)
+                {
+                    encrypted = true;
+                }
+            }
+            free(privKey);
+            privKey = NULL;
+        }
+        fclose(key);
+    }
+    else
+    {
+        std::cerr << "ERROR: Unable to open ssh key file " << keyPathParm << std::endl;
+    }
+    return encrypted;
+}
+
+static bool ValidateRequiredArgsV1(const sf_client::CommandArgsV1& argsParm)
+{
+    if(argsParm.mProject.empty())
+    {
+        return false;
+    }
+    else if(argsParm.mComment.empty())
+    {
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+sf_client::rc sf_client::connectToServer(const ServerInfoV1& serverParm, Session& sessionParm)
+{
+    if(!sessionParm.mCurlSession)
+    {
+        return failure;
+    }
+    else if(!PrivateKeyEncrypted(serverParm.mPrivateKeyPath))
+    {
+        return pkey_not_encrypted;
+    }
+
+    Curl_ServerInfo sServerInfo;
+    sServerInfo.mUrl            = serverParm.mUrl;
+    sServerInfo.mPrivateKeyPath = serverParm.mPrivateKeyPath;
+    sServerInfo.mPublicKeyPath  = serverParm.mPrivateKeyPath + ".pub";
+    sServerInfo.mPasswordPtr    = serverParm.mPasswordPtr;
+    sServerInfo.mEpwdPath       = serverParm.mEpwdPath;
+    sServerInfo.mVerbose        = serverParm.mVerbose;
+    sServerInfo.mCurlDebug      = serverParm.mCurlDebug;
+
+    return curlConnectToServer(sServerInfo, *sessionParm.mCurlSession);
+}
+
+sf_client::rc sf_client::disconnect(Session& sessionParm)
+{
+    if(!sessionParm.mCurlSession)
+    {
+        return failure;
+    }
+    curlDisconnectServer(*sessionParm.mCurlSession);
+    return success;
+}
+
+sf_client::rc sf_client::sendCommandV1(Session&                        sessionParm,
+                                       const sf_client::CommandArgsV1& argsParm,
+                                       sf_client::CommandResponseV1&   responseParm)
+{
+    rc sRc = success;
+
+    std::string sJsonRequestString;
+    std::string sJsonResponseString;
+
+    Json_CommandRequestV1  sJsonRequest;
+    Json_CommandResponseV1 sJsonResponse;
+
+    if(!ValidateRequiredArgsV1(argsParm))
+    {
+        sRc = invalid_parm;
+    }
+
+    if(success == sRc)
+    {
+        std::vector<uint8_t> sEpwdBinary;
+        bool sIsSuccess = ReadFile(sessionParm.mCurlSession->mEpwdPath, sEpwdBinary);
+        if(sIsSuccess)
+        {
+            // File is ASCII, copy directly into the string.
+            sJsonRequest.mEpwdHex = std::string(sEpwdBinary.data(),
+                                                sEpwdBinary.data() + sEpwdBinary.size());
+            RemoveAllWhitespace(sJsonRequest.mEpwdHex);
+        }
+        else
+        {
+            sRc = epwd_read_fail;
+        }
+    }
+
+    if(success == sRc)
+    {
+        sJsonRequest.mComment          = argsParm.mComment;
+        sJsonRequest.mParms            = argsParm.mExtraServerParms;
+        sJsonRequest.mPayload          = argsParm.mPayload;
+        sJsonRequest.mProject          = argsParm.mProject;
+        sJsonRequest.mSelfReportedUser = GetLocalUser() + "@" + GetLocalHost();
+
+        sRc = createCommandRequestJsonV1(sJsonRequest, sJsonRequestString);
+    }
+
+    if(success == sRc)
+    {
+        sRc = sendAndReceiveCommand(
+            *sessionParm.mCurlSession, sJsonRequestString, sJsonResponseString);
+    }
+
+    if(success == sRc)
+    {
+        sRc = parseCommandResponseJsonV1(sJsonResponseString, sJsonResponse);
+    }
+
+    if(success == sRc)
+    {
+        responseParm.mOutput     = sJsonResponse.mResult;
+        responseParm.mStdOut     = sJsonResponse.mStandardOut;
+        responseParm.mReturnCode = sJsonResponse.mReturnValue;
+    }
+
+    return sRc;
+}

--- a/src/client-c++/sf_client_lib/sf_curl.cpp
+++ b/src/client-c++/sf_client_lib/sf_curl.cpp
@@ -1,0 +1,344 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstring>
+#include <curl/curl.h>
+#include <errno.h>
+#include <iostream>
+#include <sf_client/sf_rc.h>
+#include <sf_utils/sf_utils.h>
+#include <sstream>
+#include <string>
+#include <time.h>
+#include <unistd.h>
+
+#include "sf_curl.h"
+
+#define SET_CURL_OPTION(return_code, session, option, value)                                       \
+    if(CURLE_OK == (return_code))                                                                  \
+    {                                                                                              \
+        (return_code) = curl_easy_setopt((session).mCurlPtr, (option), (value));                   \
+    }
+
+#define RUN_CURL_SESSION(return_code, session)                                                     \
+    if(CURLE_OK == (return_code))                                                                  \
+    {                                                                                              \
+        (return_code) = curl_easy_perform((session).mCurlPtr);                                     \
+    }
+
+#define WRITE_TO_SERVER(return_code, session, url, data)                                           \
+    if(CURLE_OK == (return_code))                                                                  \
+    {                                                                                              \
+        (return_code) = WriteToServer((session), (url), (data));                                   \
+    }
+
+#define READ_FROM_SERVER(return_code, session, url, data)                                          \
+    if(CURLE_OK == (return_code))                                                                  \
+    {                                                                                              \
+        (return_code) = ReadFromServer((session), (url), (data));                                  \
+    }
+
+enum
+{
+    MaxPollingTimeInSeconds = 50,
+    PollingWaitInSeconds    = 1,
+    MaxPollingAttempts      = MaxPollingTimeInSeconds / PollingWaitInSeconds,
+};
+
+const static std::string RequestExtension    = ".request";
+const static std::string RequestGoExtension  = ".request.go";
+const static std::string ResponseExtension   = ".response";
+const static std::string ResponseGoExtension = ".response.go";
+const static std::string ServerDirectory     = "dropbox/";
+
+static std::string GetFilePrefix()
+{
+    std::stringstream ss;
+    ss << GetLocalUser() << "_" << GetLocalHost() << "_" << time(NULL);
+    return ss.str();
+}
+
+struct SessionFilenames
+{
+    SessionFilenames(const std::string& urlParm)
+    {
+        const std::string sPrefix = urlParm + "/" + ServerDirectory + "/" + GetFilePrefix();
+
+        mCommandFile    = sPrefix + RequestExtension;
+        mCommandFileGo  = sPrefix + RequestGoExtension;
+        mResponseFile   = sPrefix + ResponseExtension;
+        mResponseFileGo = sPrefix + ResponseGoExtension;
+    }
+    std::string mCommandFile;
+    std::string mCommandFileGo;
+    std::string mResponseFile;
+    std::string mResponseFileGo;
+};
+
+struct CurlPayload
+{
+    CurlPayload(bool verboseParm)
+    {
+        mBytesProccessed = 0;
+        mVerbose         = verboseParm;
+    }
+    CurlPayload(const std::string& dataParm, bool verboseParm)
+    {
+        mBytesProccessed = 0;
+        mData            = dataParm;
+        mVerbose         = verboseParm;
+    }
+    std::size_t mBytesProccessed;
+    std::string mData;
+    bool        mVerbose;
+};
+
+// The buffer by default will be 16K. This should be plenty.
+size_t read_callback(char*  dataToSendPtrParm,
+                     size_t memberSizeParm,
+                     size_t numMembersParm,
+                     void*  localDataToReadParm)
+{
+    if(!dataToSendPtrParm || !dataToSendPtrParm)
+    {
+        return CURL_READFUNC_ABORT;
+    }
+    CurlPayload& sDataToRead          = *(CurlPayload*)localDataToReadParm;
+    const size_t sTotalBytesAvailable = memberSizeParm * numMembersParm;
+    const size_t sBytesRemaining      = sDataToRead.mData.size() - sDataToRead.mBytesProccessed;
+    const size_t sBytesToRead         = std::min(sTotalBytesAvailable, sBytesRemaining);
+
+    const char* sReadPtr = sDataToRead.mData.c_str() + sDataToRead.mBytesProccessed;
+    memcpy(dataToSendPtrParm, sReadPtr, sBytesToRead);
+
+    sDataToRead.mBytesProccessed += sBytesToRead;
+
+    if(sDataToRead.mVerbose)
+        std::cout << "Sent " << sBytesToRead << " bytes" << std::endl;
+
+    return sBytesToRead;
+}
+
+CURLcode WriteToServer(sf_client::Curl_Session& curlSessionParm,
+                       const std::string&       urlParm,
+                       const std::string&       srcParm)
+{
+    CURLcode sRc = CURLE_OK;
+    if(curlSessionParm.mVerbose)
+    {
+        std::cout << "WRITE_TO_SERVER: " << srcParm << std::endl;
+    }
+
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_URL, urlParm.c_str());
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_UPLOAD, 1L);
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_READFUNCTION, read_callback);
+
+    // For some reason CURLOPT_READDATA and std::string do not work properly when CurlPayload is
+    // allocated on the stack.
+    CurlPayload* sPayload = new CurlPayload(srcParm, curlSessionParm.mVerbose);
+
+    if(sPayload)
+    {
+        SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_READDATA, sPayload);
+
+        RUN_CURL_SESSION(sRc, curlSessionParm);
+        delete sPayload;
+    }
+    else
+    {
+        sRc = CURLE_OUT_OF_MEMORY;
+    }
+
+    return sRc;
+}
+
+size_t write_callback(char*  receivedDataPtrParm,
+                      size_t memberSizeParm,
+                      size_t numMembersParm,
+                      void*  localDataToWriteParm)
+{
+    if(!receivedDataPtrParm || !localDataToWriteParm)
+    {
+        return 0;
+    }
+
+    CurlPayload& sDataToWrite  = *(CurlPayload*)localDataToWriteParm;
+    std::string& sDstString    = sDataToWrite.mData;
+    const size_t sBytesToWrite = memberSizeParm * numMembersParm;
+
+    sDstString += std::string(receivedDataPtrParm, receivedDataPtrParm + sBytesToWrite);
+    sDataToWrite.mBytesProccessed += sBytesToWrite;
+
+    if(sDataToWrite.mVerbose)
+    {
+        std::cout << "Received " << sBytesToWrite << " bytes" << std::endl;
+    }
+
+    return sBytesToWrite;
+}
+
+CURLcode ReadFromServer(sf_client::Curl_Session& curlSessionParm,
+                        const std::string&       urlParm,
+                        std::string&             dstParm)
+{
+    CURLcode sRc = CURLE_OK;
+
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_URL, urlParm.c_str());
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_UPLOAD, 0L);
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_WRITEFUNCTION, write_callback);
+
+    // For some reason CURLOPT_READDATA and std::string do not work properly when CurlPayload is
+    // allocated on the stack.
+
+    CurlPayload* sPayload = new CurlPayload(curlSessionParm.mVerbose);
+    if(sPayload)
+    {
+        SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_WRITEDATA, sPayload);
+
+        RUN_CURL_SESSION(sRc, curlSessionParm);
+
+        if(CURLE_OK == sRc)
+        {
+            dstParm = sPayload->mData;
+        }
+        delete sPayload;
+    }
+    else
+    {
+        sRc = CURLE_OUT_OF_MEMORY;
+    }
+
+    if(curlSessionParm.mVerbose && (CURLE_OK == sRc))
+    {
+        std::cout << "READ_FROM_SERVER: " << dstParm << std::endl;
+    }
+
+    return sRc;
+}
+
+sf_client::rc sf_client::curlConnectToServer(const Curl_ServerInfo& serverInfoParm,
+                                             Curl_Session&          curlSessionParm)
+{
+    CURLcode sRc             = CURLE_OK;
+    curlSessionParm.mCurlPtr = NULL;
+
+    curlSessionParm.mVerbose  = serverInfoParm.mVerbose;
+    curlSessionParm.mEpwdPath = serverInfoParm.mEpwdPath;
+
+    // Init curl library
+    if(CURLE_OK == sRc)
+    {
+        sRc = curl_global_init(CURL_GLOBAL_ALL);
+    }
+
+    if(CURLE_OK == sRc)
+    {
+        curlSessionParm.mCurlPtr = curl_easy_init();
+
+        sRc = ((NULL != curlSessionParm.mCurlPtr) ? CURLE_OK : CURLE_FAILED_INIT);
+    }
+
+    if(serverInfoParm.mCurlDebug)
+        SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_VERBOSE, 1L);
+
+    SET_CURL_OPTION(
+        sRc, curlSessionParm, CURLOPT_SSH_PRIVATE_KEYFILE, serverInfoParm.mPrivateKeyPath.c_str());
+    SET_CURL_OPTION(
+        sRc, curlSessionParm, CURLOPT_SSH_PUBLIC_KEYFILE, serverInfoParm.mPublicKeyPath.c_str());
+
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_URL, serverInfoParm.mUrl.c_str());
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_PROTOCOLS, CURLPROTO_SFTP);
+
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_CONNECT_ONLY, 1L);
+
+    if(serverInfoParm.mPasswordPtr)
+        SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_KEYPASSWD, serverInfoParm.mPasswordPtr);
+
+    if(CURLE_OK == sRc)
+    {
+        sRc = curl_easy_perform(curlSessionParm.mCurlPtr);
+    }
+
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_CONNECT_ONLY, 0L);
+
+    if(curlSessionParm.mCurlPtr)
+    {
+        if(CURLE_OK == sRc)
+        {
+            curlSessionParm.mUrl = serverInfoParm.mUrl;
+        }
+        else
+        {
+            curl_easy_cleanup(curlSessionParm.mCurlPtr);
+            curlSessionParm.mCurlPtr = NULL;
+        }
+    }
+
+    return (CURLE_OK == sRc) ? success : curl_init_failure;
+}
+
+void sf_client::curlDisconnectServer(Curl_Session& curlSessionParm)
+{
+    if(curlSessionParm.mCurlPtr)
+    {
+        curl_easy_cleanup(curlSessionParm.mCurlPtr);
+    }
+    curlSessionParm.mUrl.clear();
+    curlSessionParm.mVerbose = false;
+}
+
+sf_client::rc sf_client::sendAndReceiveCommand(Curl_Session&      curlSessionParm,
+                                               const std::string& commandParm,
+                                               std::string&       responseParm)
+{
+    CURLcode sRc = CURLE_OK;
+
+    // Automatically creates four strings with the filenames for this specific session
+    SessionFilenames sSessionFileNames(curlSessionParm.mUrl);
+
+    // Init curl library
+    sRc = ((NULL != curlSessionParm.mCurlPtr) ? CURLE_OK : CURLE_FAILED_INIT);
+
+    if(curlSessionParm.mVerbose)
+        std::cout << "Prepare to WRITE" << std::endl;
+
+    WRITE_TO_SERVER(sRc, curlSessionParm, sSessionFileNames.mCommandFile, commandParm);
+
+    if(curlSessionParm.mVerbose)
+        std::cout << "Prepare to WRITE 2" << std::endl;
+    WRITE_TO_SERVER(sRc, curlSessionParm, sSessionFileNames.mCommandFileGo, "1");
+
+    std::size_t sNumPolls = 0;
+    do
+    {
+        sleep(1);
+        sNumPolls++;
+
+        std::string sResponseGo;
+        READ_FROM_SERVER(sRc, curlSessionParm, sSessionFileNames.mResponseFileGo, sResponseGo);
+
+        if(CURLE_REMOTE_FILE_NOT_FOUND == sRc)
+        {
+            // TODO: Figure out sub second polling
+            sleep(PollingWaitInSeconds);
+        }
+    } while(CURLE_REMOTE_FILE_NOT_FOUND == sRc && sNumPolls < MaxPollingAttempts);
+
+    if(curlSessionParm.mVerbose)
+        std::cout << "Prepare to READ 2" << std::endl;
+    READ_FROM_SERVER(sRc, curlSessionParm, sSessionFileNames.mResponseFile, responseParm);
+
+    return (CURLE_OK == sRc) ? success : curl_failure;
+}

--- a/src/client-c++/sf_client_lib/sf_curl.h
+++ b/src/client-c++/sf_client_lib/sf_curl.h
@@ -1,0 +1,61 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <curl/curl.h>
+
+#ifndef _SFCURL_H
+#define _SFCURL_H
+
+namespace sf_client
+{
+    struct Curl_ServerInfo
+    {
+        Curl_ServerInfo()
+        : mVerbose(false)
+        , mCurlDebug(false)
+        {
+        }
+        std::string mUrl;
+        std::string mPrivateKeyPath;
+        std::string mPublicKeyPath;
+        std::string mEpwdPath;
+        const char* mPasswordPtr;
+        bool        mVerbose;
+        bool        mCurlDebug;
+    };
+
+    struct Curl_Session
+    {
+        Curl_Session()
+        : mCurlPtr(NULL)
+        , mVerbose(false)
+        {
+        }
+        CURL*       mCurlPtr;
+        std::string mUrl;
+        std::string mEpwdPath;
+        bool        mVerbose;
+    };
+
+    rc   curlConnectToServer(const Curl_ServerInfo& serverInfoParm, Curl_Session& curlSessionParm);
+    void curlDisconnectServer(Curl_Session& curlSessionParm);
+
+    rc sendAndReceiveCommand(Curl_Session&      serverInfoParm,
+                             const std::string& commandParm,
+                             std::string&       responseParm);
+
+} // namespace sf_client
+
+#endif

--- a/src/client-c++/sf_client_lib/sf_json.cpp
+++ b/src/client-c++/sf_client_lib/sf_json.cpp
@@ -1,0 +1,240 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+#include <json-c/json.h>
+#include <sf_client/sf_rc.h>
+#include <sf_utils/sf_utils.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "sf_json.h"
+
+const static std::string JsonProjectTag   = "project";
+const static std::string JsonParameterTag = "parameters";
+const static std::string JsonUserTag      = "user";
+const static std::string JsonCommentTag   = "comment";
+const static std::string JsonEpwdTag      = "epwd";
+const static std::string JsonPayloadTag   = "payload";
+
+const static std::string JsonResultTag = "result";
+const static std::string JsonStdOutTag = "stdout";
+const static std::string JsonRetValTag = "retval";
+
+enum TagNotFoundBehavior
+{
+    ErrorOnTagNotFound,
+    SuccessOnTagNotFound
+};
+
+#define ENCODE_JSON_STRING(return_code, root_node, tag, value)                                     \
+    if(success == (return_code))                                                                   \
+    {                                                                                              \
+        (return_code) = EncodeString((root_node), (tag), (value));                                 \
+    }
+
+#define ENCODE_JSON_BINARY(return_code, root_node, tag, value)                                     \
+    if(success == (return_code))                                                                   \
+    {                                                                                              \
+        (return_code) = EncodeString((root_node), (tag), GetHexStringFromBinary(value));           \
+    }
+
+#define DECODE_JSON_STRING(return_code, root_node, tag, value, tag_not_found_behavior)             \
+    if(success == (return_code))                                                                   \
+    {                                                                                              \
+        (return_code) = DecodeString((root_node), (tag), (value), (tag_not_found_behavior));       \
+    }
+
+#define DECODE_JSON_BINARY(return_code, root_node, tag, value, tag_not_found_behavior)             \
+    if(success == (return_code))                                                                   \
+    {                                                                                              \
+        std::string sTmpString;                                                                    \
+        (return_code) = DecodeString((root_node), (tag), sTmpString, (tag_not_found_behavior));    \
+        (value)       = GetBinaryFromHexString(sTmpString);                                        \
+    }
+#define DECODE_JSON_INT(return_code, root_node, tag, value, tag_not_found_behavior)                \
+    if(success == (return_code))                                                                   \
+    {                                                                                              \
+        (return_code) = DecodeInt((root_node), (tag), (value), (tag_not_found_behavior));          \
+    }
+
+sf_client::rc EncodeString(struct json_object* jsonParentParm,
+                           const std::string&  tagParm,
+                           const std::string&  valueParm)
+{
+    sf_client::rc sRc = sf_client::success;
+
+    if(jsonParentParm)
+    {
+        struct json_object* sJsonString = json_object_new_string(valueParm.c_str());
+        if(sJsonString)
+        {
+            json_object_object_add(jsonParentParm, tagParm.c_str(), sJsonString);
+        }
+        else
+        {
+            sRc = sf_client::json_new_obj_fail;
+        }
+    }
+    else
+    {
+        sRc = sf_client::json_invalid_parm;
+    }
+    return sRc;
+}
+
+sf_client::rc DecodeString(struct json_object*       jsonParentParm,
+                           const std::string&        tagParm,
+                           std::string&              valueParm,
+                           const TagNotFoundBehavior tagNotFoundBehaviorParm)
+{
+    sf_client::rc sRc = sf_client::success;
+    valueParm.clear();
+
+    if(jsonParentParm)
+    {
+        json_object* sJsonChild = NULL;
+        json_object_object_get_ex(jsonParentParm, tagParm.c_str(), &sJsonChild);
+
+        if(sJsonChild)
+        {
+            const char* sJsonString = json_object_get_string(sJsonChild);
+            if(sJsonString)
+            {
+                valueParm = std::string(sJsonString);
+            }
+            else
+            {
+                sRc = sf_client::json_invalid_object_type;
+            }
+        }
+        else
+        {
+            if(tagNotFoundBehaviorParm == ErrorOnTagNotFound)
+            {
+                // Tag not found, nothing to parse
+                sRc = sf_client::json_tag_not_found;
+            }
+        }
+    }
+    else
+    {
+        sRc = sf_client::json_invalid_parm;
+    }
+
+    return sRc;
+}
+
+sf_client::rc DecodeInt(struct json_object*       jsonParentParm,
+                        const std::string&        tagParm,
+                        int&                      valueParm,
+                        const TagNotFoundBehavior tagNotFoundBehaviorParm)
+{
+    sf_client::rc sRc = sf_client::success;
+    valueParm         = 0;
+
+    if(jsonParentParm)
+    {
+        json_object* sJsonChild = NULL;
+        json_object_object_get_ex(jsonParentParm, tagParm.c_str(), &sJsonChild);
+
+        if(sJsonChild)
+        {
+            valueParm = json_object_get_int(sJsonChild);
+        }
+        else
+        {
+            if(tagNotFoundBehaviorParm == ErrorOnTagNotFound)
+            {
+                // Tag not found, nothing to parse
+                sRc = sf_client::json_tag_not_found;
+            };
+        }
+    }
+    else
+    {
+        sRc = sf_client::json_invalid_parm;
+    }
+
+    return sRc;
+}
+
+sf_client::rc sf_client::createCommandRequestJsonV1(const Json_CommandRequestV1& requestParm,
+                                                    std::string&                 dstJsonParm)
+{
+    rc sRc = success;
+
+    struct json_object* sRootObject = NULL;
+
+    sRootObject = json_object_new_object();
+
+    if(!sRootObject)
+    {
+        sRc = json_new_obj_fail;
+    }
+
+    ENCODE_JSON_STRING(sRc, sRootObject, JsonProjectTag, requestParm.mProject);
+    ENCODE_JSON_STRING(sRc, sRootObject, JsonParameterTag, requestParm.mParms);
+    ENCODE_JSON_STRING(sRc, sRootObject, JsonUserTag, requestParm.mSelfReportedUser);
+    ENCODE_JSON_STRING(sRc, sRootObject, JsonCommentTag, requestParm.mComment);
+    ENCODE_JSON_STRING(sRc, sRootObject, JsonEpwdTag, requestParm.mEpwdHex);
+    ENCODE_JSON_BINARY(sRc, sRootObject, JsonPayloadTag, requestParm.mPayload);
+
+    if(success == sRc)
+    {
+        const char* sEncodedJsonPtr = json_object_to_json_string(sRootObject);
+        if(sEncodedJsonPtr)
+        {
+            dstJsonParm = std::string(sEncodedJsonPtr);
+        }
+        else
+        {
+            sRc = json_convert_to_string_fail;
+        }
+    }
+
+    if(sRootObject)
+        json_object_put(sRootObject);
+
+    return sRc;
+}
+
+sf_client::rc sf_client::parseCommandResponseJsonV1(const std::string&      jsonParm,
+                                                    Json_CommandResponseV1& dstResponseParm)
+{
+    rc sRc = success;
+    dstResponseParm.clear();
+
+    struct json_object* sRootObject = json_tokener_parse(jsonParm.c_str());
+
+    if(!sRootObject)
+    {
+        sRc = json_parse_root_fail;
+    }
+
+    DECODE_JSON_INT(
+        sRc, sRootObject, JsonRetValTag, dstResponseParm.mReturnValue, ErrorOnTagNotFound);
+
+    DECODE_JSON_BINARY(
+        sRc, sRootObject, JsonResultTag, dstResponseParm.mResult, SuccessOnTagNotFound);
+    DECODE_JSON_STRING(
+        sRc, sRootObject, JsonStdOutTag, dstResponseParm.mStandardOut, SuccessOnTagNotFound);
+
+    if(sRootObject)
+        json_object_put(sRootObject);
+
+    return sRc;
+}

--- a/src/client-c++/sf_client_lib/sf_json.h
+++ b/src/client-c++/sf_client_lib/sf_json.h
@@ -1,0 +1,58 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <sf_client/sf_rc.h>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#ifndef _SFJSON_H
+#define _SFJSON_H
+
+namespace sf_client
+{
+    struct Json_CommandRequestV1
+    {
+        std::string          mProject;
+        std::string          mParms;
+        std::string          mSelfReportedUser;
+        std::string          mComment;
+        std::string          mEpwdHex;
+        std::vector<uint8_t> mPayload;
+    };
+
+    struct Json_CommandResponseV1
+    {
+        std::vector<uint8_t> mResult;
+        std::string          mStandardOut;
+        int                  mReturnValue;
+
+        void clear()
+        {
+            mResult.clear();
+            mStandardOut.clear();
+            mReturnValue = 0;
+        };
+    };
+
+    rc createCommandRequestJsonV1(const Json_CommandRequestV1& requestParm,
+                                  std::string&                 dstJsonParm);
+
+    rc parseCommandResponseJsonV1(const std::string&      jsonParm,
+                                  Json_CommandResponseV1& dstResponseParm);
+
+} // namespace sf_client
+
+#endif

--- a/src/client-c++/sf_pkcs11/include/pkcs11/.clang-format
+++ b/src/client-c++/sf_pkcs11/include/pkcs11/.clang-format
@@ -1,0 +1,4 @@
+---
+DisableFormat: true
+SortIncludes: Never
+...

--- a/src/client-c++/sf_pkcs11/include/pkcs11/pkcs11.h
+++ b/src/client-c++/sf_pkcs11/include/pkcs11/pkcs11.h
@@ -1,0 +1,265 @@
+/* Copyright (c) OASIS Open 2016. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+        
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+ */
+
+#ifndef _PKCS11_H_
+#define _PKCS11_H_ 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Before including this file (pkcs11.h) (or pkcs11t.h by
+ * itself), 5 platform-specific macros must be defined.  These
+ * macros are described below, and typical definitions for them
+ * are also given.  Be advised that these definitions can depend
+ * on both the platform and the compiler used (and possibly also
+ * on whether a Cryptoki library is linked statically or
+ * dynamically).
+ *
+ * In addition to defining these 5 macros, the packing convention
+ * for Cryptoki structures should be set.  The Cryptoki
+ * convention on packing is that structures should be 1-byte
+ * aligned.
+ *
+ * If you're using Microsoft Developer Studio 5.0 to produce
+ * Win32 stuff, this might be done by using the following
+ * preprocessor directive before including pkcs11.h or pkcs11t.h:
+ *
+ * #pragma pack(push, cryptoki, 1)
+ *
+ * and using the following preprocessor directive after including
+ * pkcs11.h or pkcs11t.h:
+ *
+ * #pragma pack(pop, cryptoki)
+ *
+ * If you're using an earlier version of Microsoft Developer
+ * Studio to produce Win16 stuff, this might be done by using
+ * the following preprocessor directive before including
+ * pkcs11.h or pkcs11t.h:
+ *
+ * #pragma pack(1)
+ *
+ * In a UNIX environment, you're on your own for this.  You might
+ * not need to do (or be able to do!) anything.
+ *
+ *
+ * Now for the macros:
+ *
+ *
+ * 1. CK_PTR: The indirection string for making a pointer to an
+ * object.  It can be used like this:
+ *
+ * typedef CK_BYTE CK_PTR CK_BYTE_PTR;
+ *
+ * If you're using Microsoft Developer Studio 5.0 to produce
+ * Win32 stuff, it might be defined by:
+ *
+ * #define CK_PTR *
+ *
+ * If you're using an earlier version of Microsoft Developer
+ * Studio to produce Win16 stuff, it might be defined by:
+ *
+ * #define CK_PTR far *
+ *
+ * In a typical UNIX environment, it might be defined by:
+ *
+ * #define CK_PTR *
+ *
+ *
+ * 2. CK_DECLARE_FUNCTION(returnType, name): A macro which makes
+ * an importable Cryptoki library function declaration out of a
+ * return type and a function name.  It should be used in the
+ * following fashion:
+ *
+ * extern CK_DECLARE_FUNCTION(CK_RV, C_Initialize)(
+ *   CK_VOID_PTR pReserved
+ * );
+ *
+ * If you're using Microsoft Developer Studio 5.0 to declare a
+ * function in a Win32 Cryptoki .dll, it might be defined by:
+ *
+ * #define CK_DECLARE_FUNCTION(returnType, name) \
+ *   returnType __declspec(dllimport) name
+ *
+ * If you're using an earlier version of Microsoft Developer
+ * Studio to declare a function in a Win16 Cryptoki .dll, it
+ * might be defined by:
+ *
+ * #define CK_DECLARE_FUNCTION(returnType, name) \
+ *   returnType __export _far _pascal name
+ *
+ * In a UNIX environment, it might be defined by:
+ *
+ * #define CK_DECLARE_FUNCTION(returnType, name) \
+ *   returnType name
+ *
+ *
+ * 3. CK_DECLARE_FUNCTION_POINTER(returnType, name): A macro
+ * which makes a Cryptoki API function pointer declaration or
+ * function pointer type declaration out of a return type and a
+ * function name.  It should be used in the following fashion:
+ *
+ * // Define funcPtr to be a pointer to a Cryptoki API function
+ * // taking arguments args and returning CK_RV.
+ * CK_DECLARE_FUNCTION_POINTER(CK_RV, funcPtr)(args);
+ *
+ * or
+ *
+ * // Define funcPtrType to be the type of a pointer to a
+ * // Cryptoki API function taking arguments args and returning
+ * // CK_RV, and then define funcPtr to be a variable of type
+ * // funcPtrType.
+ * typedef CK_DECLARE_FUNCTION_POINTER(CK_RV, funcPtrType)(args);
+ * funcPtrType funcPtr;
+ *
+ * If you're using Microsoft Developer Studio 5.0 to access
+ * functions in a Win32 Cryptoki .dll, in might be defined by:
+ *
+ * #define CK_DECLARE_FUNCTION_POINTER(returnType, name) \
+ *   returnType __declspec(dllimport) (* name)
+ *
+ * If you're using an earlier version of Microsoft Developer
+ * Studio to access functions in a Win16 Cryptoki .dll, it might
+ * be defined by:
+ *
+ * #define CK_DECLARE_FUNCTION_POINTER(returnType, name) \
+ *   returnType __export _far _pascal (* name)
+ *
+ * In a UNIX environment, it might be defined by:
+ *
+ * #define CK_DECLARE_FUNCTION_POINTER(returnType, name) \
+ *   returnType (* name)
+ *
+ *
+ * 4. CK_CALLBACK_FUNCTION(returnType, name): A macro which makes
+ * a function pointer type for an application callback out of
+ * a return type for the callback and a name for the callback.
+ * It should be used in the following fashion:
+ *
+ * CK_CALLBACK_FUNCTION(CK_RV, myCallback)(args);
+ *
+ * to declare a function pointer, myCallback, to a callback
+ * which takes arguments args and returns a CK_RV.  It can also
+ * be used like this:
+ *
+ * typedef CK_CALLBACK_FUNCTION(CK_RV, myCallbackType)(args);
+ * myCallbackType myCallback;
+ *
+ * If you're using Microsoft Developer Studio 5.0 to do Win32
+ * Cryptoki development, it might be defined by:
+ *
+ * #define CK_CALLBACK_FUNCTION(returnType, name) \
+ *   returnType (* name)
+ *
+ * If you're using an earlier version of Microsoft Developer
+ * Studio to do Win16 development, it might be defined by:
+ *
+ * #define CK_CALLBACK_FUNCTION(returnType, name) \
+ *   returnType _far _pascal (* name)
+ *
+ * In a UNIX environment, it might be defined by:
+ *
+ * #define CK_CALLBACK_FUNCTION(returnType, name) \
+ *   returnType (* name)
+ *
+ *
+ * 5. NULL_PTR: This macro is the value of a NULL pointer.
+ *
+ * In any ANSI/ISO C environment (and in many others as well),
+ * this should best be defined by
+ *
+ * #ifndef NULL_PTR
+ * #define NULL_PTR 0
+ * #endif
+ */
+
+
+/* All the various Cryptoki types and #define'd values are in the
+ * file pkcs11t.h.
+ */
+#include "pkcs11t.h"
+
+#define __PASTE(x,y)      x##y
+
+
+/* ==============================================================
+ * Define the "extern" form of all the entry points.
+ * ==============================================================
+ */
+
+#define CK_NEED_ARG_LIST  1
+#define CK_PKCS11_FUNCTION_INFO(name) \
+  extern CK_DECLARE_FUNCTION(CK_RV, name)
+
+/* pkcs11f.h has all the information about the Cryptoki
+ * function prototypes.
+ */
+#include "pkcs11f.h"
+
+#undef CK_NEED_ARG_LIST
+#undef CK_PKCS11_FUNCTION_INFO
+
+
+/* ==============================================================
+ * Define the typedef form of all the entry points.  That is, for
+ * each Cryptoki function C_XXX, define a type CK_C_XXX which is
+ * a pointer to that kind of function.
+ * ==============================================================
+ */
+
+#define CK_NEED_ARG_LIST  1
+#define CK_PKCS11_FUNCTION_INFO(name) \
+  typedef CK_DECLARE_FUNCTION_POINTER(CK_RV, __PASTE(CK_,name))
+
+/* pkcs11f.h has all the information about the Cryptoki
+ * function prototypes.
+ */
+#include "pkcs11f.h"
+
+#undef CK_NEED_ARG_LIST
+#undef CK_PKCS11_FUNCTION_INFO
+
+
+/* ==============================================================
+ * Define structed vector of entry points.  A CK_FUNCTION_LIST
+ * contains a CK_VERSION indicating a library's Cryptoki version
+ * and then a whole slew of function pointers to the routines in
+ * the library.  This type was declared, but not defined, in
+ * pkcs11t.h.
+ * ==============================================================
+ */
+
+#define CK_PKCS11_FUNCTION_INFO(name) \
+  __PASTE(CK_,name) name;
+
+struct CK_FUNCTION_LIST {
+
+  CK_VERSION    version;  /* Cryptoki version */
+
+/* Pile all the function pointers into the CK_FUNCTION_LIST. */
+/* pkcs11f.h has all the information about the Cryptoki
+ * function prototypes.
+ */
+#include "pkcs11f.h"
+
+};
+
+#undef CK_PKCS11_FUNCTION_INFO
+
+
+#undef __PASTE
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PKCS11_H_ */
+

--- a/src/client-c++/sf_pkcs11/include/pkcs11/pkcs11f.h
+++ b/src/client-c++/sf_pkcs11/include/pkcs11/pkcs11f.h
@@ -1,0 +1,939 @@
+/* Copyright (c) OASIS Open 2016. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+        
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+ */
+
+/* This header file contains pretty much everything about all the
+ * Cryptoki function prototypes.  Because this information is
+ * used for more than just declaring function prototypes, the
+ * order of the functions appearing herein is important, and
+ * should not be altered.
+ */
+
+/* General-purpose */
+
+/* C_Initialize initializes the Cryptoki library. */
+CK_PKCS11_FUNCTION_INFO(C_Initialize)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_VOID_PTR   pInitArgs  /* if this is not NULL_PTR, it gets
+                            * cast to CK_C_INITIALIZE_ARGS_PTR
+                            * and dereferenced
+                            */
+);
+#endif
+
+
+/* C_Finalize indicates that an application is done with the
+ * Cryptoki library.
+ */
+CK_PKCS11_FUNCTION_INFO(C_Finalize)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_VOID_PTR   pReserved  /* reserved.  Should be NULL_PTR */
+);
+#endif
+
+
+/* C_GetInfo returns general information about Cryptoki. */
+CK_PKCS11_FUNCTION_INFO(C_GetInfo)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_INFO_PTR   pInfo  /* location that receives information */
+);
+#endif
+
+
+/* C_GetFunctionList returns the function list. */
+CK_PKCS11_FUNCTION_INFO(C_GetFunctionList)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_FUNCTION_LIST_PTR_PTR ppFunctionList  /* receives pointer to
+                                            * function list
+                                            */
+);
+#endif
+
+
+
+/* Slot and token management */
+
+/* C_GetSlotList obtains a list of slots in the system. */
+CK_PKCS11_FUNCTION_INFO(C_GetSlotList)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_BBOOL       tokenPresent,  /* only slots with tokens */
+  CK_SLOT_ID_PTR pSlotList,     /* receives array of slot IDs */
+  CK_ULONG_PTR   pulCount       /* receives number of slots */
+);
+#endif
+
+
+/* C_GetSlotInfo obtains information about a particular slot in
+ * the system.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetSlotInfo)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID       slotID,  /* the ID of the slot */
+  CK_SLOT_INFO_PTR pInfo    /* receives the slot information */
+);
+#endif
+
+
+/* C_GetTokenInfo obtains information about a particular token
+ * in the system.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetTokenInfo)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID        slotID,  /* ID of the token's slot */
+  CK_TOKEN_INFO_PTR pInfo    /* receives the token information */
+);
+#endif
+
+
+/* C_GetMechanismList obtains a list of mechanism types
+ * supported by a token.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetMechanismList)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID            slotID,          /* ID of token's slot */
+  CK_MECHANISM_TYPE_PTR pMechanismList,  /* gets mech. array */
+  CK_ULONG_PTR          pulCount         /* gets # of mechs. */
+);
+#endif
+
+
+/* C_GetMechanismInfo obtains information about a particular
+ * mechanism possibly supported by a token.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetMechanismInfo)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID            slotID,  /* ID of the token's slot */
+  CK_MECHANISM_TYPE     type,    /* type of mechanism */
+  CK_MECHANISM_INFO_PTR pInfo    /* receives mechanism info */
+);
+#endif
+
+
+/* C_InitToken initializes a token. */
+CK_PKCS11_FUNCTION_INFO(C_InitToken)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID      slotID,    /* ID of the token's slot */
+  CK_UTF8CHAR_PTR pPin,      /* the SO's initial PIN */
+  CK_ULONG        ulPinLen,  /* length in bytes of the PIN */
+  CK_UTF8CHAR_PTR pLabel     /* 32-byte token label (blank padded) */
+);
+#endif
+
+
+/* C_InitPIN initializes the normal user's PIN. */
+CK_PKCS11_FUNCTION_INFO(C_InitPIN)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_UTF8CHAR_PTR   pPin,      /* the normal user's PIN */
+  CK_ULONG          ulPinLen   /* length in bytes of the PIN */
+);
+#endif
+
+
+/* C_SetPIN modifies the PIN of the user who is logged in. */
+CK_PKCS11_FUNCTION_INFO(C_SetPIN)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_UTF8CHAR_PTR   pOldPin,   /* the old PIN */
+  CK_ULONG          ulOldLen,  /* length of the old PIN */
+  CK_UTF8CHAR_PTR   pNewPin,   /* the new PIN */
+  CK_ULONG          ulNewLen   /* length of the new PIN */
+);
+#endif
+
+
+
+/* Session management */
+
+/* C_OpenSession opens a session between an application and a
+ * token.
+ */
+CK_PKCS11_FUNCTION_INFO(C_OpenSession)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID            slotID,        /* the slot's ID */
+  CK_FLAGS              flags,         /* from CK_SESSION_INFO */
+  CK_VOID_PTR           pApplication,  /* passed to callback */
+  CK_NOTIFY             Notify,        /* callback function */
+  CK_SESSION_HANDLE_PTR phSession      /* gets session handle */
+);
+#endif
+
+
+/* C_CloseSession closes a session between an application and a
+ * token.
+ */
+CK_PKCS11_FUNCTION_INFO(C_CloseSession)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession  /* the session's handle */
+);
+#endif
+
+
+/* C_CloseAllSessions closes all sessions with a token. */
+CK_PKCS11_FUNCTION_INFO(C_CloseAllSessions)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SLOT_ID     slotID  /* the token's slot */
+);
+#endif
+
+
+/* C_GetSessionInfo obtains information about the session. */
+CK_PKCS11_FUNCTION_INFO(C_GetSessionInfo)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE   hSession,  /* the session's handle */
+  CK_SESSION_INFO_PTR pInfo      /* receives session info */
+);
+#endif
+
+
+/* C_GetOperationState obtains the state of the cryptographic operation
+ * in a session.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetOperationState)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,             /* session's handle */
+  CK_BYTE_PTR       pOperationState,      /* gets state */
+  CK_ULONG_PTR      pulOperationStateLen  /* gets state length */
+);
+#endif
+
+
+/* C_SetOperationState restores the state of the cryptographic
+ * operation in a session.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SetOperationState)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR      pOperationState,      /* holds state */
+  CK_ULONG         ulOperationStateLen,  /* holds state length */
+  CK_OBJECT_HANDLE hEncryptionKey,       /* en/decryption key */
+  CK_OBJECT_HANDLE hAuthenticationKey    /* sign/verify key */
+);
+#endif
+
+
+/* C_Login logs a user into a token. */
+CK_PKCS11_FUNCTION_INFO(C_Login)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_USER_TYPE      userType,  /* the user type */
+  CK_UTF8CHAR_PTR   pPin,      /* the user's PIN */
+  CK_ULONG          ulPinLen   /* the length of the PIN */
+);
+#endif
+
+
+/* C_Logout logs a user out from a token. */
+CK_PKCS11_FUNCTION_INFO(C_Logout)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession  /* the session's handle */
+);
+#endif
+
+
+
+/* Object management */
+
+/* C_CreateObject creates a new object. */
+CK_PKCS11_FUNCTION_INFO(C_CreateObject)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_ATTRIBUTE_PTR  pTemplate,   /* the object's template */
+  CK_ULONG          ulCount,     /* attributes in template */
+  CK_OBJECT_HANDLE_PTR phObject  /* gets new object's handle. */
+);
+#endif
+
+
+/* C_CopyObject copies an object, creating a new object for the
+ * copy.
+ */
+CK_PKCS11_FUNCTION_INFO(C_CopyObject)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE    hSession,    /* the session's handle */
+  CK_OBJECT_HANDLE     hObject,     /* the object's handle */
+  CK_ATTRIBUTE_PTR     pTemplate,   /* template for new object */
+  CK_ULONG             ulCount,     /* attributes in template */
+  CK_OBJECT_HANDLE_PTR phNewObject  /* receives handle of copy */
+);
+#endif
+
+
+/* C_DestroyObject destroys an object. */
+CK_PKCS11_FUNCTION_INFO(C_DestroyObject)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_OBJECT_HANDLE  hObject    /* the object's handle */
+);
+#endif
+
+
+/* C_GetObjectSize gets the size of an object in bytes. */
+CK_PKCS11_FUNCTION_INFO(C_GetObjectSize)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_OBJECT_HANDLE  hObject,   /* the object's handle */
+  CK_ULONG_PTR      pulSize    /* receives size of object */
+);
+#endif
+
+
+/* C_GetAttributeValue obtains the value of one or more object
+ * attributes.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetAttributeValue)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_OBJECT_HANDLE  hObject,    /* the object's handle */
+  CK_ATTRIBUTE_PTR  pTemplate,  /* specifies attrs; gets vals */
+  CK_ULONG          ulCount     /* attributes in template */
+);
+#endif
+
+
+/* C_SetAttributeValue modifies the value of one or more object
+ * attributes.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SetAttributeValue)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_OBJECT_HANDLE  hObject,    /* the object's handle */
+  CK_ATTRIBUTE_PTR  pTemplate,  /* specifies attrs and values */
+  CK_ULONG          ulCount     /* attributes in template */
+);
+#endif
+
+
+/* C_FindObjectsInit initializes a search for token and session
+ * objects that match a template.
+ */
+CK_PKCS11_FUNCTION_INFO(C_FindObjectsInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_ATTRIBUTE_PTR  pTemplate,  /* attribute values to match */
+  CK_ULONG          ulCount     /* attrs in search template */
+);
+#endif
+
+
+/* C_FindObjects continues a search for token and session
+ * objects that match a template, obtaining additional object
+ * handles.
+ */
+CK_PKCS11_FUNCTION_INFO(C_FindObjects)
+#ifdef CK_NEED_ARG_LIST
+(
+ CK_SESSION_HANDLE    hSession,          /* session's handle */
+ CK_OBJECT_HANDLE_PTR phObject,          /* gets obj. handles */
+ CK_ULONG             ulMaxObjectCount,  /* max handles to get */
+ CK_ULONG_PTR         pulObjectCount     /* actual # returned */
+);
+#endif
+
+
+/* C_FindObjectsFinal finishes a search for token and session
+ * objects.
+ */
+CK_PKCS11_FUNCTION_INFO(C_FindObjectsFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession  /* the session's handle */
+);
+#endif
+
+
+
+/* Encryption and decryption */
+
+/* C_EncryptInit initializes an encryption operation. */
+CK_PKCS11_FUNCTION_INFO(C_EncryptInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the encryption mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of encryption key */
+);
+#endif
+
+
+/* C_Encrypt encrypts single-part data. */
+CK_PKCS11_FUNCTION_INFO(C_Encrypt)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR       pData,               /* the plaintext data */
+  CK_ULONG          ulDataLen,           /* bytes of plaintext */
+  CK_BYTE_PTR       pEncryptedData,      /* gets ciphertext */
+  CK_ULONG_PTR      pulEncryptedDataLen  /* gets c-text size */
+);
+#endif
+
+
+/* C_EncryptUpdate continues a multiple-part encryption
+ * operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_EncryptUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,           /* session's handle */
+  CK_BYTE_PTR       pPart,              /* the plaintext data */
+  CK_ULONG          ulPartLen,          /* plaintext data len */
+  CK_BYTE_PTR       pEncryptedPart,     /* gets ciphertext */
+  CK_ULONG_PTR      pulEncryptedPartLen /* gets c-text size */
+);
+#endif
+
+
+/* C_EncryptFinal finishes a multiple-part encryption
+ * operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_EncryptFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,                /* session handle */
+  CK_BYTE_PTR       pLastEncryptedPart,      /* last c-text */
+  CK_ULONG_PTR      pulLastEncryptedPartLen  /* gets last size */
+);
+#endif
+
+
+/* C_DecryptInit initializes a decryption operation. */
+CK_PKCS11_FUNCTION_INFO(C_DecryptInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the decryption mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of decryption key */
+);
+#endif
+
+
+/* C_Decrypt decrypts encrypted data in a single part. */
+CK_PKCS11_FUNCTION_INFO(C_Decrypt)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,           /* session's handle */
+  CK_BYTE_PTR       pEncryptedData,     /* ciphertext */
+  CK_ULONG          ulEncryptedDataLen, /* ciphertext length */
+  CK_BYTE_PTR       pData,              /* gets plaintext */
+  CK_ULONG_PTR      pulDataLen          /* gets p-text size */
+);
+#endif
+
+
+/* C_DecryptUpdate continues a multiple-part decryption
+ * operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DecryptUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR       pEncryptedPart,      /* encrypted data */
+  CK_ULONG          ulEncryptedPartLen,  /* input length */
+  CK_BYTE_PTR       pPart,               /* gets plaintext */
+  CK_ULONG_PTR      pulPartLen           /* p-text size */
+);
+#endif
+
+
+/* C_DecryptFinal finishes a multiple-part decryption
+ * operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DecryptFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,       /* the session's handle */
+  CK_BYTE_PTR       pLastPart,      /* gets plaintext */
+  CK_ULONG_PTR      pulLastPartLen  /* p-text size */
+);
+#endif
+
+
+
+/* Message digesting */
+
+/* C_DigestInit initializes a message-digesting operation. */
+CK_PKCS11_FUNCTION_INFO(C_DigestInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism  /* the digesting mechanism */
+);
+#endif
+
+
+/* C_Digest digests data in a single part. */
+CK_PKCS11_FUNCTION_INFO(C_Digest)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,     /* the session's handle */
+  CK_BYTE_PTR       pData,        /* data to be digested */
+  CK_ULONG          ulDataLen,    /* bytes of data to digest */
+  CK_BYTE_PTR       pDigest,      /* gets the message digest */
+  CK_ULONG_PTR      pulDigestLen  /* gets digest length */
+);
+#endif
+
+
+/* C_DigestUpdate continues a multiple-part message-digesting
+ * operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DigestUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_BYTE_PTR       pPart,     /* data to be digested */
+  CK_ULONG          ulPartLen  /* bytes of data to be digested */
+);
+#endif
+
+
+/* C_DigestKey continues a multi-part message-digesting
+ * operation, by digesting the value of a secret key as part of
+ * the data already digested.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DigestKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_OBJECT_HANDLE  hKey       /* secret key to digest */
+);
+#endif
+
+
+/* C_DigestFinal finishes a multiple-part message-digesting
+ * operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DigestFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,     /* the session's handle */
+  CK_BYTE_PTR       pDigest,      /* gets the message digest */
+  CK_ULONG_PTR      pulDigestLen  /* gets byte count of digest */
+);
+#endif
+
+
+
+/* Signing and MACing */
+
+/* C_SignInit initializes a signature (private key encryption)
+ * operation, where the signature is (will be) an appendix to
+ * the data, and plaintext cannot be recovered from the
+ * signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SignInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the signature mechanism */
+  CK_OBJECT_HANDLE  hKey         /* handle of signature key */
+);
+#endif
+
+
+/* C_Sign signs (encrypts with private key) data in a single
+ * part, where the signature is (will be) an appendix to the
+ * data, and plaintext cannot be recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_Sign)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_BYTE_PTR       pData,           /* the data to sign */
+  CK_ULONG          ulDataLen,       /* count of bytes to sign */
+  CK_BYTE_PTR       pSignature,      /* gets the signature */
+  CK_ULONG_PTR      pulSignatureLen  /* gets signature length */
+);
+#endif
+
+
+/* C_SignUpdate continues a multiple-part signature operation,
+ * where the signature is (will be) an appendix to the data,
+ * and plaintext cannot be recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SignUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_BYTE_PTR       pPart,     /* the data to sign */
+  CK_ULONG          ulPartLen  /* count of bytes to sign */
+);
+#endif
+
+
+/* C_SignFinal finishes a multiple-part signature operation,
+ * returning the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SignFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_BYTE_PTR       pSignature,      /* gets the signature */
+  CK_ULONG_PTR      pulSignatureLen  /* gets signature length */
+);
+#endif
+
+
+/* C_SignRecoverInit initializes a signature operation, where
+ * the data can be recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SignRecoverInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,   /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism, /* the signature mechanism */
+  CK_OBJECT_HANDLE  hKey        /* handle of the signature key */
+);
+#endif
+
+
+/* C_SignRecover signs data in a single operation, where the
+ * data can be recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SignRecover)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_BYTE_PTR       pData,           /* the data to sign */
+  CK_ULONG          ulDataLen,       /* count of bytes to sign */
+  CK_BYTE_PTR       pSignature,      /* gets the signature */
+  CK_ULONG_PTR      pulSignatureLen  /* gets signature length */
+);
+#endif
+
+
+
+/* Verifying signatures and MACs */
+
+/* C_VerifyInit initializes a verification operation, where the
+ * signature is an appendix to the data, and plaintext cannot
+ * cannot be recovered from the signature (e.g. DSA).
+ */
+CK_PKCS11_FUNCTION_INFO(C_VerifyInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the verification mechanism */
+  CK_OBJECT_HANDLE  hKey         /* verification key */
+);
+#endif
+
+
+/* C_Verify verifies a signature in a single-part operation,
+ * where the signature is an appendix to the data, and plaintext
+ * cannot be recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_Verify)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,       /* the session's handle */
+  CK_BYTE_PTR       pData,          /* signed data */
+  CK_ULONG          ulDataLen,      /* length of signed data */
+  CK_BYTE_PTR       pSignature,     /* signature */
+  CK_ULONG          ulSignatureLen  /* signature length*/
+);
+#endif
+
+
+/* C_VerifyUpdate continues a multiple-part verification
+ * operation, where the signature is an appendix to the data,
+ * and plaintext cannot be recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_VerifyUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_BYTE_PTR       pPart,     /* signed data */
+  CK_ULONG          ulPartLen  /* length of signed data */
+);
+#endif
+
+
+/* C_VerifyFinal finishes a multiple-part verification
+ * operation, checking the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_VerifyFinal)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,       /* the session's handle */
+  CK_BYTE_PTR       pSignature,     /* signature to verify */
+  CK_ULONG          ulSignatureLen  /* signature length */
+);
+#endif
+
+
+/* C_VerifyRecoverInit initializes a signature verification
+ * operation, where the data is recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_VerifyRecoverInit)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,  /* the verification mechanism */
+  CK_OBJECT_HANDLE  hKey         /* verification key */
+);
+#endif
+
+
+/* C_VerifyRecover verifies a signature in a single-part
+ * operation, where the data is recovered from the signature.
+ */
+CK_PKCS11_FUNCTION_INFO(C_VerifyRecover)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_BYTE_PTR       pSignature,      /* signature to verify */
+  CK_ULONG          ulSignatureLen,  /* signature length */
+  CK_BYTE_PTR       pData,           /* gets signed data */
+  CK_ULONG_PTR      pulDataLen       /* gets signed data len */
+);
+#endif
+
+
+
+/* Dual-function cryptographic operations */
+
+/* C_DigestEncryptUpdate continues a multiple-part digesting
+ * and encryption operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DigestEncryptUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR       pPart,               /* the plaintext data */
+  CK_ULONG          ulPartLen,           /* plaintext length */
+  CK_BYTE_PTR       pEncryptedPart,      /* gets ciphertext */
+  CK_ULONG_PTR      pulEncryptedPartLen  /* gets c-text length */
+);
+#endif
+
+
+/* C_DecryptDigestUpdate continues a multiple-part decryption and
+ * digesting operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DecryptDigestUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR       pEncryptedPart,      /* ciphertext */
+  CK_ULONG          ulEncryptedPartLen,  /* ciphertext length */
+  CK_BYTE_PTR       pPart,               /* gets plaintext */
+  CK_ULONG_PTR      pulPartLen           /* gets plaintext len */
+);
+#endif
+
+
+/* C_SignEncryptUpdate continues a multiple-part signing and
+ * encryption operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SignEncryptUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR       pPart,               /* the plaintext data */
+  CK_ULONG          ulPartLen,           /* plaintext length */
+  CK_BYTE_PTR       pEncryptedPart,      /* gets ciphertext */
+  CK_ULONG_PTR      pulEncryptedPartLen  /* gets c-text length */
+);
+#endif
+
+
+/* C_DecryptVerifyUpdate continues a multiple-part decryption and
+ * verify operation.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DecryptVerifyUpdate)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,            /* session's handle */
+  CK_BYTE_PTR       pEncryptedPart,      /* ciphertext */
+  CK_ULONG          ulEncryptedPartLen,  /* ciphertext length */
+  CK_BYTE_PTR       pPart,               /* gets plaintext */
+  CK_ULONG_PTR      pulPartLen           /* gets p-text length */
+);
+#endif
+
+
+
+/* Key management */
+
+/* C_GenerateKey generates a secret key, creating a new key
+ * object.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GenerateKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE    hSession,    /* the session's handle */
+  CK_MECHANISM_PTR     pMechanism,  /* key generation mech. */
+  CK_ATTRIBUTE_PTR     pTemplate,   /* template for new key */
+  CK_ULONG             ulCount,     /* # of attrs in template */
+  CK_OBJECT_HANDLE_PTR phKey        /* gets handle of new key */
+);
+#endif
+
+
+/* C_GenerateKeyPair generates a public-key/private-key pair,
+ * creating new key objects.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GenerateKeyPair)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE    hSession,                    /* session handle */
+  CK_MECHANISM_PTR     pMechanism,                  /* key-gen mech. */
+  CK_ATTRIBUTE_PTR     pPublicKeyTemplate,          /* template for pub. key */
+  CK_ULONG             ulPublicKeyAttributeCount,   /* # pub. attrs. */
+  CK_ATTRIBUTE_PTR     pPrivateKeyTemplate,         /* template for priv. key */
+  CK_ULONG             ulPrivateKeyAttributeCount,  /* # priv.  attrs. */
+  CK_OBJECT_HANDLE_PTR phPublicKey,                 /* gets pub. key handle */
+  CK_OBJECT_HANDLE_PTR phPrivateKey                 /* gets priv. key handle */
+);
+#endif
+
+
+/* C_WrapKey wraps (i.e., encrypts) a key. */
+CK_PKCS11_FUNCTION_INFO(C_WrapKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,        /* the session's handle */
+  CK_MECHANISM_PTR  pMechanism,      /* the wrapping mechanism */
+  CK_OBJECT_HANDLE  hWrappingKey,    /* wrapping key */
+  CK_OBJECT_HANDLE  hKey,            /* key to be wrapped */
+  CK_BYTE_PTR       pWrappedKey,     /* gets wrapped key */
+  CK_ULONG_PTR      pulWrappedKeyLen /* gets wrapped key size */
+);
+#endif
+
+
+/* C_UnwrapKey unwraps (decrypts) a wrapped key, creating a new
+ * key object.
+ */
+CK_PKCS11_FUNCTION_INFO(C_UnwrapKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE    hSession,          /* session's handle */
+  CK_MECHANISM_PTR     pMechanism,        /* unwrapping mech. */
+  CK_OBJECT_HANDLE     hUnwrappingKey,    /* unwrapping key */
+  CK_BYTE_PTR          pWrappedKey,       /* the wrapped key */
+  CK_ULONG             ulWrappedKeyLen,   /* wrapped key len */
+  CK_ATTRIBUTE_PTR     pTemplate,         /* new key template */
+  CK_ULONG             ulAttributeCount,  /* template length */
+  CK_OBJECT_HANDLE_PTR phKey              /* gets new handle */
+);
+#endif
+
+
+/* C_DeriveKey derives a key from a base key, creating a new key
+ * object.
+ */
+CK_PKCS11_FUNCTION_INFO(C_DeriveKey)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE    hSession,          /* session's handle */
+  CK_MECHANISM_PTR     pMechanism,        /* key deriv. mech. */
+  CK_OBJECT_HANDLE     hBaseKey,          /* base key */
+  CK_ATTRIBUTE_PTR     pTemplate,         /* new key template */
+  CK_ULONG             ulAttributeCount,  /* template length */
+  CK_OBJECT_HANDLE_PTR phKey              /* gets new handle */
+);
+#endif
+
+
+
+/* Random number generation */
+
+/* C_SeedRandom mixes additional seed material into the token's
+ * random number generator.
+ */
+CK_PKCS11_FUNCTION_INFO(C_SeedRandom)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,  /* the session's handle */
+  CK_BYTE_PTR       pSeed,     /* the seed material */
+  CK_ULONG          ulSeedLen  /* length of seed material */
+);
+#endif
+
+
+/* C_GenerateRandom generates random data. */
+CK_PKCS11_FUNCTION_INFO(C_GenerateRandom)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession,    /* the session's handle */
+  CK_BYTE_PTR       RandomData,  /* receives the random data */
+  CK_ULONG          ulRandomLen  /* # of bytes to generate */
+);
+#endif
+
+
+
+/* Parallel function management */
+
+/* C_GetFunctionStatus is a legacy function; it obtains an
+ * updated status of a function running in parallel with an
+ * application.
+ */
+CK_PKCS11_FUNCTION_INFO(C_GetFunctionStatus)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession  /* the session's handle */
+);
+#endif
+
+
+/* C_CancelFunction is a legacy function; it cancels a function
+ * running in parallel.
+ */
+CK_PKCS11_FUNCTION_INFO(C_CancelFunction)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_SESSION_HANDLE hSession  /* the session's handle */
+);
+#endif
+
+
+/* C_WaitForSlotEvent waits for a slot event (token insertion,
+ * removal, etc.) to occur.
+ */
+CK_PKCS11_FUNCTION_INFO(C_WaitForSlotEvent)
+#ifdef CK_NEED_ARG_LIST
+(
+  CK_FLAGS flags,        /* blocking/nonblocking flag */
+  CK_SLOT_ID_PTR pSlot,  /* location that receives the slot ID */
+  CK_VOID_PTR pRserved   /* reserved.  Should be NULL_PTR */
+);
+#endif
+

--- a/src/client-c++/sf_pkcs11/include/pkcs11/pkcs11t.h
+++ b/src/client-c++/sf_pkcs11/include/pkcs11/pkcs11t.h
@@ -1,0 +1,2003 @@
+/* Copyright (c) OASIS Open 2016. All Rights Reserved./
+ * /Distributed under the terms of the OASIS IPR Policy,
+ * [http://www.oasis-open.org/policies-guidelines/ipr], AS-IS, WITHOUT ANY
+ * IMPLIED OR EXPRESS WARRANTY; there is no warranty of MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE or NONINFRINGEMENT of the rights of others.
+ */
+        
+/* Latest version of the specification:
+ * http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+ */
+
+/* See top of pkcs11.h for information about the macros that
+ * must be defined and the structure-packing conventions that
+ * must be set before including this file.
+ */
+
+#ifndef _PKCS11T_H_
+#define _PKCS11T_H_ 1
+
+#define CRYPTOKI_VERSION_MAJOR          2
+#define CRYPTOKI_VERSION_MINOR          40
+#define CRYPTOKI_VERSION_AMENDMENT      0
+
+#define CK_TRUE         1
+#define CK_FALSE        0
+
+#ifndef CK_DISABLE_TRUE_FALSE
+#ifndef FALSE
+#define FALSE CK_FALSE
+#endif
+#ifndef TRUE
+#define TRUE CK_TRUE
+#endif
+#endif
+
+/* an unsigned 8-bit value */
+typedef unsigned char     CK_BYTE;
+
+/* an unsigned 8-bit character */
+typedef CK_BYTE           CK_CHAR;
+
+/* an 8-bit UTF-8 character */
+typedef CK_BYTE           CK_UTF8CHAR;
+
+/* a BYTE-sized Boolean flag */
+typedef CK_BYTE           CK_BBOOL;
+
+/* an unsigned value, at least 32 bits long */
+typedef unsigned long int CK_ULONG;
+
+/* a signed value, the same size as a CK_ULONG */
+typedef long int          CK_LONG;
+
+/* at least 32 bits; each bit is a Boolean flag */
+typedef CK_ULONG          CK_FLAGS;
+
+
+/* some special values for certain CK_ULONG variables */
+#define CK_UNAVAILABLE_INFORMATION      (~0UL)
+#define CK_EFFECTIVELY_INFINITE         0UL
+
+
+typedef CK_BYTE     CK_PTR   CK_BYTE_PTR;
+typedef CK_CHAR     CK_PTR   CK_CHAR_PTR;
+typedef CK_UTF8CHAR CK_PTR   CK_UTF8CHAR_PTR;
+typedef CK_ULONG    CK_PTR   CK_ULONG_PTR;
+typedef void        CK_PTR   CK_VOID_PTR;
+
+/* Pointer to a CK_VOID_PTR-- i.e., pointer to pointer to void */
+typedef CK_VOID_PTR CK_PTR CK_VOID_PTR_PTR;
+
+
+/* The following value is always invalid if used as a session
+ * handle or object handle
+ */
+#define CK_INVALID_HANDLE       0UL
+
+
+typedef struct CK_VERSION {
+  CK_BYTE       major;  /* integer portion of version number */
+  CK_BYTE       minor;  /* 1/100ths portion of version number */
+} CK_VERSION;
+
+typedef CK_VERSION CK_PTR CK_VERSION_PTR;
+
+
+typedef struct CK_INFO {
+  CK_VERSION    cryptokiVersion;     /* Cryptoki interface ver */
+  CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
+  CK_FLAGS      flags;               /* must be zero */
+  CK_UTF8CHAR   libraryDescription[32];  /* blank padded */
+  CK_VERSION    libraryVersion;          /* version of library */
+} CK_INFO;
+
+typedef CK_INFO CK_PTR    CK_INFO_PTR;
+
+
+/* CK_NOTIFICATION enumerates the types of notifications that
+ * Cryptoki provides to an application
+ */
+typedef CK_ULONG CK_NOTIFICATION;
+#define CKN_SURRENDER           0UL
+#define CKN_OTP_CHANGED         1UL
+
+typedef CK_ULONG          CK_SLOT_ID;
+
+typedef CK_SLOT_ID CK_PTR CK_SLOT_ID_PTR;
+
+
+/* CK_SLOT_INFO provides information about a slot */
+typedef struct CK_SLOT_INFO {
+  CK_UTF8CHAR   slotDescription[64];  /* blank padded */
+  CK_UTF8CHAR   manufacturerID[32];   /* blank padded */
+  CK_FLAGS      flags;
+
+  CK_VERSION    hardwareVersion;  /* version of hardware */
+  CK_VERSION    firmwareVersion;  /* version of firmware */
+} CK_SLOT_INFO;
+
+/* flags: bit flags that provide capabilities of the slot
+ *      Bit Flag              Mask        Meaning
+ */
+#define CKF_TOKEN_PRESENT     0x00000001UL  /* a token is there */
+#define CKF_REMOVABLE_DEVICE  0x00000002UL  /* removable devices*/
+#define CKF_HW_SLOT           0x00000004UL  /* hardware slot */
+
+typedef CK_SLOT_INFO CK_PTR CK_SLOT_INFO_PTR;
+
+
+/* CK_TOKEN_INFO provides information about a token */
+typedef struct CK_TOKEN_INFO {
+  CK_UTF8CHAR   label[32];           /* blank padded */
+  CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
+  CK_UTF8CHAR   model[16];           /* blank padded */
+  CK_CHAR       serialNumber[16];    /* blank padded */
+  CK_FLAGS      flags;               /* see below */
+
+  CK_ULONG      ulMaxSessionCount;     /* max open sessions */
+  CK_ULONG      ulSessionCount;        /* sess. now open */
+  CK_ULONG      ulMaxRwSessionCount;   /* max R/W sessions */
+  CK_ULONG      ulRwSessionCount;      /* R/W sess. now open */
+  CK_ULONG      ulMaxPinLen;           /* in bytes */
+  CK_ULONG      ulMinPinLen;           /* in bytes */
+  CK_ULONG      ulTotalPublicMemory;   /* in bytes */
+  CK_ULONG      ulFreePublicMemory;    /* in bytes */
+  CK_ULONG      ulTotalPrivateMemory;  /* in bytes */
+  CK_ULONG      ulFreePrivateMemory;   /* in bytes */
+  CK_VERSION    hardwareVersion;       /* version of hardware */
+  CK_VERSION    firmwareVersion;       /* version of firmware */
+  CK_CHAR       utcTime[16];           /* time */
+} CK_TOKEN_INFO;
+
+/* The flags parameter is defined as follows:
+ *      Bit Flag                    Mask        Meaning
+ */
+#define CKF_RNG                     0x00000001UL  /* has random # generator */
+#define CKF_WRITE_PROTECTED         0x00000002UL  /* token is write-protected */
+#define CKF_LOGIN_REQUIRED          0x00000004UL  /* user must login */
+#define CKF_USER_PIN_INITIALIZED    0x00000008UL  /* normal user's PIN is set */
+
+/* CKF_RESTORE_KEY_NOT_NEEDED.  If it is set,
+ * that means that *every* time the state of cryptographic
+ * operations of a session is successfully saved, all keys
+ * needed to continue those operations are stored in the state
+ */
+#define CKF_RESTORE_KEY_NOT_NEEDED  0x00000020UL
+
+/* CKF_CLOCK_ON_TOKEN.  If it is set, that means
+ * that the token has some sort of clock.  The time on that
+ * clock is returned in the token info structure
+ */
+#define CKF_CLOCK_ON_TOKEN          0x00000040UL
+
+/* CKF_PROTECTED_AUTHENTICATION_PATH.  If it is
+ * set, that means that there is some way for the user to login
+ * without sending a PIN through the Cryptoki library itself
+ */
+#define CKF_PROTECTED_AUTHENTICATION_PATH 0x00000100UL
+
+/* CKF_DUAL_CRYPTO_OPERATIONS.  If it is true,
+ * that means that a single session with the token can perform
+ * dual simultaneous cryptographic operations (digest and
+ * encrypt; decrypt and digest; sign and encrypt; and decrypt
+ * and sign)
+ */
+#define CKF_DUAL_CRYPTO_OPERATIONS  0x00000200UL
+
+/* CKF_TOKEN_INITIALIZED. If it is true, the
+ * token has been initialized using C_InitializeToken or an
+ * equivalent mechanism outside the scope of PKCS #11.
+ * Calling C_InitializeToken when this flag is set will cause
+ * the token to be reinitialized.
+ */
+#define CKF_TOKEN_INITIALIZED       0x00000400UL
+
+/* CKF_SECONDARY_AUTHENTICATION. If it is
+ * true, the token supports secondary authentication for
+ * private key objects.
+ */
+#define CKF_SECONDARY_AUTHENTICATION  0x00000800UL
+
+/* CKF_USER_PIN_COUNT_LOW. If it is true, an
+ * incorrect user login PIN has been entered at least once
+ * since the last successful authentication.
+ */
+#define CKF_USER_PIN_COUNT_LOW       0x00010000UL
+
+/* CKF_USER_PIN_FINAL_TRY. If it is true,
+ * supplying an incorrect user PIN will it to become locked.
+ */
+#define CKF_USER_PIN_FINAL_TRY       0x00020000UL
+
+/* CKF_USER_PIN_LOCKED. If it is true, the
+ * user PIN has been locked. User login to the token is not
+ * possible.
+ */
+#define CKF_USER_PIN_LOCKED          0x00040000UL
+
+/* CKF_USER_PIN_TO_BE_CHANGED. If it is true,
+ * the user PIN value is the default value set by token
+ * initialization or manufacturing, or the PIN has been
+ * expired by the card.
+ */
+#define CKF_USER_PIN_TO_BE_CHANGED   0x00080000UL
+
+/* CKF_SO_PIN_COUNT_LOW. If it is true, an
+ * incorrect SO login PIN has been entered at least once since
+ * the last successful authentication.
+ */
+#define CKF_SO_PIN_COUNT_LOW         0x00100000UL
+
+/* CKF_SO_PIN_FINAL_TRY. If it is true,
+ * supplying an incorrect SO PIN will it to become locked.
+ */
+#define CKF_SO_PIN_FINAL_TRY         0x00200000UL
+
+/* CKF_SO_PIN_LOCKED. If it is true, the SO
+ * PIN has been locked. SO login to the token is not possible.
+ */
+#define CKF_SO_PIN_LOCKED            0x00400000UL
+
+/* CKF_SO_PIN_TO_BE_CHANGED. If it is true,
+ * the SO PIN value is the default value set by token
+ * initialization or manufacturing, or the PIN has been
+ * expired by the card.
+ */
+#define CKF_SO_PIN_TO_BE_CHANGED     0x00800000UL
+
+#define CKF_ERROR_STATE              0x01000000UL
+
+typedef CK_TOKEN_INFO CK_PTR CK_TOKEN_INFO_PTR;
+
+
+/* CK_SESSION_HANDLE is a Cryptoki-assigned value that
+ * identifies a session
+ */
+typedef CK_ULONG          CK_SESSION_HANDLE;
+
+typedef CK_SESSION_HANDLE CK_PTR CK_SESSION_HANDLE_PTR;
+
+
+/* CK_USER_TYPE enumerates the types of Cryptoki users */
+typedef CK_ULONG          CK_USER_TYPE;
+/* Security Officer */
+#define CKU_SO                  0UL
+/* Normal user */
+#define CKU_USER                1UL
+/* Context specific */
+#define CKU_CONTEXT_SPECIFIC    2UL
+
+/* CK_STATE enumerates the session states */
+typedef CK_ULONG          CK_STATE;
+#define CKS_RO_PUBLIC_SESSION   0UL
+#define CKS_RO_USER_FUNCTIONS   1UL
+#define CKS_RW_PUBLIC_SESSION   2UL
+#define CKS_RW_USER_FUNCTIONS   3UL
+#define CKS_RW_SO_FUNCTIONS     4UL
+
+/* CK_SESSION_INFO provides information about a session */
+typedef struct CK_SESSION_INFO {
+  CK_SLOT_ID    slotID;
+  CK_STATE      state;
+  CK_FLAGS      flags;          /* see below */
+  CK_ULONG      ulDeviceError;  /* device-dependent error code */
+} CK_SESSION_INFO;
+
+/* The flags are defined in the following table:
+ *      Bit Flag                Mask        Meaning
+ */
+#define CKF_RW_SESSION          0x00000002UL /* session is r/w */
+#define CKF_SERIAL_SESSION      0x00000004UL /* no parallel    */
+
+typedef CK_SESSION_INFO CK_PTR CK_SESSION_INFO_PTR;
+
+
+/* CK_OBJECT_HANDLE is a token-specific identifier for an
+ * object
+ */
+typedef CK_ULONG          CK_OBJECT_HANDLE;
+
+typedef CK_OBJECT_HANDLE CK_PTR CK_OBJECT_HANDLE_PTR;
+
+
+/* CK_OBJECT_CLASS is a value that identifies the classes (or
+ * types) of objects that Cryptoki recognizes.  It is defined
+ * as follows:
+ */
+typedef CK_ULONG          CK_OBJECT_CLASS;
+
+/* The following classes of objects are defined: */
+#define CKO_DATA              0x00000000UL
+#define CKO_CERTIFICATE       0x00000001UL
+#define CKO_PUBLIC_KEY        0x00000002UL
+#define CKO_PRIVATE_KEY       0x00000003UL
+#define CKO_SECRET_KEY        0x00000004UL
+#define CKO_HW_FEATURE        0x00000005UL
+#define CKO_DOMAIN_PARAMETERS 0x00000006UL
+#define CKO_MECHANISM         0x00000007UL
+#define CKO_OTP_KEY           0x00000008UL
+
+#define CKO_VENDOR_DEFINED    0x80000000UL
+
+typedef CK_OBJECT_CLASS CK_PTR CK_OBJECT_CLASS_PTR;
+
+/* CK_HW_FEATURE_TYPE is a value that identifies the hardware feature type
+ * of an object with CK_OBJECT_CLASS equal to CKO_HW_FEATURE.
+ */
+typedef CK_ULONG          CK_HW_FEATURE_TYPE;
+
+/* The following hardware feature types are defined */
+#define CKH_MONOTONIC_COUNTER  0x00000001UL
+#define CKH_CLOCK              0x00000002UL
+#define CKH_USER_INTERFACE     0x00000003UL
+#define CKH_VENDOR_DEFINED     0x80000000UL
+
+/* CK_KEY_TYPE is a value that identifies a key type */
+typedef CK_ULONG          CK_KEY_TYPE;
+
+/* the following key types are defined: */
+#define CKK_RSA                 0x00000000UL
+#define CKK_DSA                 0x00000001UL
+#define CKK_DH                  0x00000002UL
+#define CKK_ECDSA               0x00000003UL /* Deprecated */
+#define CKK_EC                  0x00000003UL
+#define CKK_X9_42_DH            0x00000004UL
+#define CKK_KEA                 0x00000005UL
+#define CKK_GENERIC_SECRET      0x00000010UL
+#define CKK_RC2                 0x00000011UL
+#define CKK_RC4                 0x00000012UL
+#define CKK_DES                 0x00000013UL
+#define CKK_DES2                0x00000014UL
+#define CKK_DES3                0x00000015UL
+#define CKK_CAST                0x00000016UL
+#define CKK_CAST3               0x00000017UL
+#define CKK_CAST5               0x00000018UL /* Deprecated */
+#define CKK_CAST128             0x00000018UL
+#define CKK_RC5                 0x00000019UL
+#define CKK_IDEA                0x0000001AUL
+#define CKK_SKIPJACK            0x0000001BUL
+#define CKK_BATON               0x0000001CUL
+#define CKK_JUNIPER             0x0000001DUL
+#define CKK_CDMF                0x0000001EUL
+#define CKK_AES                 0x0000001FUL
+#define CKK_BLOWFISH            0x00000020UL
+#define CKK_TWOFISH             0x00000021UL
+#define CKK_SECURID             0x00000022UL
+#define CKK_HOTP                0x00000023UL
+#define CKK_ACTI                0x00000024UL
+#define CKK_CAMELLIA            0x00000025UL
+#define CKK_ARIA                0x00000026UL
+
+#define CKK_MD5_HMAC            0x00000027UL
+#define CKK_SHA_1_HMAC          0x00000028UL
+#define CKK_RIPEMD128_HMAC      0x00000029UL
+#define CKK_RIPEMD160_HMAC      0x0000002AUL
+#define CKK_SHA256_HMAC         0x0000002BUL
+#define CKK_SHA384_HMAC         0x0000002CUL
+#define CKK_SHA512_HMAC         0x0000002DUL
+#define CKK_SHA224_HMAC         0x0000002EUL
+
+#define CKK_SEED                0x0000002FUL
+#define CKK_GOSTR3410           0x00000030UL
+#define CKK_GOSTR3411           0x00000031UL
+#define CKK_GOST28147           0x00000032UL
+
+
+
+#define CKK_VENDOR_DEFINED      0x80000000UL
+
+
+/* CK_CERTIFICATE_TYPE is a value that identifies a certificate
+ * type
+ */
+typedef CK_ULONG          CK_CERTIFICATE_TYPE;
+
+#define CK_CERTIFICATE_CATEGORY_UNSPECIFIED     0UL
+#define CK_CERTIFICATE_CATEGORY_TOKEN_USER      1UL
+#define CK_CERTIFICATE_CATEGORY_AUTHORITY       2UL
+#define CK_CERTIFICATE_CATEGORY_OTHER_ENTITY    3UL
+
+#define CK_SECURITY_DOMAIN_UNSPECIFIED     0UL
+#define CK_SECURITY_DOMAIN_MANUFACTURER    1UL
+#define CK_SECURITY_DOMAIN_OPERATOR        2UL
+#define CK_SECURITY_DOMAIN_THIRD_PARTY     3UL
+
+
+/* The following certificate types are defined: */
+#define CKC_X_509               0x00000000UL
+#define CKC_X_509_ATTR_CERT     0x00000001UL
+#define CKC_WTLS                0x00000002UL
+#define CKC_VENDOR_DEFINED      0x80000000UL
+
+
+/* CK_ATTRIBUTE_TYPE is a value that identifies an attribute
+ * type
+ */
+typedef CK_ULONG          CK_ATTRIBUTE_TYPE;
+
+/* The CKF_ARRAY_ATTRIBUTE flag identifies an attribute which
+ * consists of an array of values.
+ */
+#define CKF_ARRAY_ATTRIBUTE     0x40000000UL
+
+/* The following OTP-related defines relate to the CKA_OTP_FORMAT attribute */
+#define CK_OTP_FORMAT_DECIMAL           0UL
+#define CK_OTP_FORMAT_HEXADECIMAL       1UL
+#define CK_OTP_FORMAT_ALPHANUMERIC      2UL
+#define CK_OTP_FORMAT_BINARY            3UL
+
+/* The following OTP-related defines relate to the CKA_OTP_..._REQUIREMENT
+ * attributes
+ */
+#define CK_OTP_PARAM_IGNORED            0UL
+#define CK_OTP_PARAM_OPTIONAL           1UL
+#define CK_OTP_PARAM_MANDATORY          2UL
+
+/* The following attribute types are defined: */
+#define CKA_CLASS              0x00000000UL
+#define CKA_TOKEN              0x00000001UL
+#define CKA_PRIVATE            0x00000002UL
+#define CKA_LABEL              0x00000003UL
+#define CKA_APPLICATION        0x00000010UL
+#define CKA_VALUE              0x00000011UL
+#define CKA_OBJECT_ID          0x00000012UL
+#define CKA_CERTIFICATE_TYPE   0x00000080UL
+#define CKA_ISSUER             0x00000081UL
+#define CKA_SERIAL_NUMBER      0x00000082UL
+#define CKA_AC_ISSUER          0x00000083UL
+#define CKA_OWNER              0x00000084UL
+#define CKA_ATTR_TYPES         0x00000085UL
+#define CKA_TRUSTED            0x00000086UL
+#define CKA_CERTIFICATE_CATEGORY        0x00000087UL
+#define CKA_JAVA_MIDP_SECURITY_DOMAIN   0x00000088UL
+#define CKA_URL                         0x00000089UL
+#define CKA_HASH_OF_SUBJECT_PUBLIC_KEY  0x0000008AUL
+#define CKA_HASH_OF_ISSUER_PUBLIC_KEY   0x0000008BUL
+#define CKA_NAME_HASH_ALGORITHM         0x0000008CUL
+#define CKA_CHECK_VALUE                 0x00000090UL
+
+#define CKA_KEY_TYPE           0x00000100UL
+#define CKA_SUBJECT            0x00000101UL
+#define CKA_ID                 0x00000102UL
+#define CKA_SENSITIVE          0x00000103UL
+#define CKA_ENCRYPT            0x00000104UL
+#define CKA_DECRYPT            0x00000105UL
+#define CKA_WRAP               0x00000106UL
+#define CKA_UNWRAP             0x00000107UL
+#define CKA_SIGN               0x00000108UL
+#define CKA_SIGN_RECOVER       0x00000109UL
+#define CKA_VERIFY             0x0000010AUL
+#define CKA_VERIFY_RECOVER     0x0000010BUL
+#define CKA_DERIVE             0x0000010CUL
+#define CKA_START_DATE         0x00000110UL
+#define CKA_END_DATE           0x00000111UL
+#define CKA_MODULUS            0x00000120UL
+#define CKA_MODULUS_BITS       0x00000121UL
+#define CKA_PUBLIC_EXPONENT    0x00000122UL
+#define CKA_PRIVATE_EXPONENT   0x00000123UL
+#define CKA_PRIME_1            0x00000124UL
+#define CKA_PRIME_2            0x00000125UL
+#define CKA_EXPONENT_1         0x00000126UL
+#define CKA_EXPONENT_2         0x00000127UL
+#define CKA_COEFFICIENT        0x00000128UL
+#define CKA_PUBLIC_KEY_INFO    0x00000129UL
+#define CKA_PRIME              0x00000130UL
+#define CKA_SUBPRIME           0x00000131UL
+#define CKA_BASE               0x00000132UL
+
+#define CKA_PRIME_BITS         0x00000133UL
+#define CKA_SUBPRIME_BITS      0x00000134UL
+#define CKA_SUB_PRIME_BITS     CKA_SUBPRIME_BITS
+
+#define CKA_VALUE_BITS         0x00000160UL
+#define CKA_VALUE_LEN          0x00000161UL
+#define CKA_EXTRACTABLE        0x00000162UL
+#define CKA_LOCAL              0x00000163UL
+#define CKA_NEVER_EXTRACTABLE  0x00000164UL
+#define CKA_ALWAYS_SENSITIVE   0x00000165UL
+#define CKA_KEY_GEN_MECHANISM  0x00000166UL
+
+#define CKA_MODIFIABLE         0x00000170UL
+#define CKA_COPYABLE           0x00000171UL
+
+#define CKA_DESTROYABLE        0x00000172UL
+
+#define CKA_ECDSA_PARAMS       0x00000180UL /* Deprecated */
+#define CKA_EC_PARAMS          0x00000180UL
+
+#define CKA_EC_POINT           0x00000181UL
+
+#define CKA_SECONDARY_AUTH     0x00000200UL /* Deprecated */
+#define CKA_AUTH_PIN_FLAGS     0x00000201UL /* Deprecated */
+
+#define CKA_ALWAYS_AUTHENTICATE  0x00000202UL
+
+#define CKA_WRAP_WITH_TRUSTED    0x00000210UL
+#define CKA_WRAP_TEMPLATE        (CKF_ARRAY_ATTRIBUTE|0x00000211UL)
+#define CKA_UNWRAP_TEMPLATE      (CKF_ARRAY_ATTRIBUTE|0x00000212UL)
+#define CKA_DERIVE_TEMPLATE      (CKF_ARRAY_ATTRIBUTE|0x00000213UL)
+
+#define CKA_OTP_FORMAT                0x00000220UL
+#define CKA_OTP_LENGTH                0x00000221UL
+#define CKA_OTP_TIME_INTERVAL         0x00000222UL
+#define CKA_OTP_USER_FRIENDLY_MODE    0x00000223UL
+#define CKA_OTP_CHALLENGE_REQUIREMENT 0x00000224UL
+#define CKA_OTP_TIME_REQUIREMENT      0x00000225UL
+#define CKA_OTP_COUNTER_REQUIREMENT   0x00000226UL
+#define CKA_OTP_PIN_REQUIREMENT       0x00000227UL
+#define CKA_OTP_COUNTER               0x0000022EUL
+#define CKA_OTP_TIME                  0x0000022FUL
+#define CKA_OTP_USER_IDENTIFIER       0x0000022AUL
+#define CKA_OTP_SERVICE_IDENTIFIER    0x0000022BUL
+#define CKA_OTP_SERVICE_LOGO          0x0000022CUL
+#define CKA_OTP_SERVICE_LOGO_TYPE     0x0000022DUL
+
+#define CKA_GOSTR3410_PARAMS            0x00000250UL
+#define CKA_GOSTR3411_PARAMS            0x00000251UL
+#define CKA_GOST28147_PARAMS            0x00000252UL
+
+#define CKA_HW_FEATURE_TYPE             0x00000300UL
+#define CKA_RESET_ON_INIT               0x00000301UL
+#define CKA_HAS_RESET                   0x00000302UL
+
+#define CKA_PIXEL_X                     0x00000400UL
+#define CKA_PIXEL_Y                     0x00000401UL
+#define CKA_RESOLUTION                  0x00000402UL
+#define CKA_CHAR_ROWS                   0x00000403UL
+#define CKA_CHAR_COLUMNS                0x00000404UL
+#define CKA_COLOR                       0x00000405UL
+#define CKA_BITS_PER_PIXEL              0x00000406UL
+#define CKA_CHAR_SETS                   0x00000480UL
+#define CKA_ENCODING_METHODS            0x00000481UL
+#define CKA_MIME_TYPES                  0x00000482UL
+#define CKA_MECHANISM_TYPE              0x00000500UL
+#define CKA_REQUIRED_CMS_ATTRIBUTES     0x00000501UL
+#define CKA_DEFAULT_CMS_ATTRIBUTES      0x00000502UL
+#define CKA_SUPPORTED_CMS_ATTRIBUTES    0x00000503UL
+#define CKA_ALLOWED_MECHANISMS          (CKF_ARRAY_ATTRIBUTE|0x00000600UL)
+
+#define CKA_VENDOR_DEFINED              0x80000000UL
+
+/* CK_ATTRIBUTE is a structure that includes the type, length
+ * and value of an attribute
+ */
+typedef struct CK_ATTRIBUTE {
+  CK_ATTRIBUTE_TYPE type;
+  CK_VOID_PTR       pValue;
+  CK_ULONG          ulValueLen;  /* in bytes */
+} CK_ATTRIBUTE;
+
+typedef CK_ATTRIBUTE CK_PTR CK_ATTRIBUTE_PTR;
+
+/* CK_DATE is a structure that defines a date */
+typedef struct CK_DATE{
+  CK_CHAR       year[4];   /* the year ("1900" - "9999") */
+  CK_CHAR       month[2];  /* the month ("01" - "12") */
+  CK_CHAR       day[2];    /* the day   ("01" - "31") */
+} CK_DATE;
+
+
+/* CK_MECHANISM_TYPE is a value that identifies a mechanism
+ * type
+ */
+typedef CK_ULONG          CK_MECHANISM_TYPE;
+
+/* the following mechanism types are defined: */
+#define CKM_RSA_PKCS_KEY_PAIR_GEN      0x00000000UL
+#define CKM_RSA_PKCS                   0x00000001UL
+#define CKM_RSA_9796                   0x00000002UL
+#define CKM_RSA_X_509                  0x00000003UL
+
+#define CKM_MD2_RSA_PKCS               0x00000004UL
+#define CKM_MD5_RSA_PKCS               0x00000005UL
+#define CKM_SHA1_RSA_PKCS              0x00000006UL
+
+#define CKM_RIPEMD128_RSA_PKCS         0x00000007UL
+#define CKM_RIPEMD160_RSA_PKCS         0x00000008UL
+#define CKM_RSA_PKCS_OAEP              0x00000009UL
+
+#define CKM_RSA_X9_31_KEY_PAIR_GEN     0x0000000AUL
+#define CKM_RSA_X9_31                  0x0000000BUL
+#define CKM_SHA1_RSA_X9_31             0x0000000CUL
+#define CKM_RSA_PKCS_PSS               0x0000000DUL
+#define CKM_SHA1_RSA_PKCS_PSS          0x0000000EUL
+
+#define CKM_DSA_KEY_PAIR_GEN           0x00000010UL
+#define CKM_DSA                        0x00000011UL
+#define CKM_DSA_SHA1                   0x00000012UL
+#define CKM_DSA_SHA224                 0x00000013UL
+#define CKM_DSA_SHA256                 0x00000014UL
+#define CKM_DSA_SHA384                 0x00000015UL
+#define CKM_DSA_SHA512                 0x00000016UL
+
+#define CKM_DH_PKCS_KEY_PAIR_GEN       0x00000020UL
+#define CKM_DH_PKCS_DERIVE             0x00000021UL
+
+#define CKM_X9_42_DH_KEY_PAIR_GEN      0x00000030UL
+#define CKM_X9_42_DH_DERIVE            0x00000031UL
+#define CKM_X9_42_DH_HYBRID_DERIVE     0x00000032UL
+#define CKM_X9_42_MQV_DERIVE           0x00000033UL
+
+#define CKM_SHA256_RSA_PKCS            0x00000040UL
+#define CKM_SHA384_RSA_PKCS            0x00000041UL
+#define CKM_SHA512_RSA_PKCS            0x00000042UL
+#define CKM_SHA256_RSA_PKCS_PSS        0x00000043UL
+#define CKM_SHA384_RSA_PKCS_PSS        0x00000044UL
+#define CKM_SHA512_RSA_PKCS_PSS        0x00000045UL
+
+#define CKM_SHA224_RSA_PKCS            0x00000046UL
+#define CKM_SHA224_RSA_PKCS_PSS        0x00000047UL
+
+#define CKM_SHA512_224                 0x00000048UL
+#define CKM_SHA512_224_HMAC            0x00000049UL
+#define CKM_SHA512_224_HMAC_GENERAL    0x0000004AUL
+#define CKM_SHA512_224_KEY_DERIVATION  0x0000004BUL
+#define CKM_SHA512_256                 0x0000004CUL
+#define CKM_SHA512_256_HMAC            0x0000004DUL
+#define CKM_SHA512_256_HMAC_GENERAL    0x0000004EUL
+#define CKM_SHA512_256_KEY_DERIVATION  0x0000004FUL
+
+#define CKM_SHA512_T                   0x00000050UL
+#define CKM_SHA512_T_HMAC              0x00000051UL
+#define CKM_SHA512_T_HMAC_GENERAL      0x00000052UL
+#define CKM_SHA512_T_KEY_DERIVATION    0x00000053UL
+
+#define CKM_RC2_KEY_GEN                0x00000100UL
+#define CKM_RC2_ECB                    0x00000101UL
+#define CKM_RC2_CBC                    0x00000102UL
+#define CKM_RC2_MAC                    0x00000103UL
+
+#define CKM_RC2_MAC_GENERAL            0x00000104UL
+#define CKM_RC2_CBC_PAD                0x00000105UL
+
+#define CKM_RC4_KEY_GEN                0x00000110UL
+#define CKM_RC4                        0x00000111UL
+#define CKM_DES_KEY_GEN                0x00000120UL
+#define CKM_DES_ECB                    0x00000121UL
+#define CKM_DES_CBC                    0x00000122UL
+#define CKM_DES_MAC                    0x00000123UL
+
+#define CKM_DES_MAC_GENERAL            0x00000124UL
+#define CKM_DES_CBC_PAD                0x00000125UL
+
+#define CKM_DES2_KEY_GEN               0x00000130UL
+#define CKM_DES3_KEY_GEN               0x00000131UL
+#define CKM_DES3_ECB                   0x00000132UL
+#define CKM_DES3_CBC                   0x00000133UL
+#define CKM_DES3_MAC                   0x00000134UL
+
+#define CKM_DES3_MAC_GENERAL           0x00000135UL
+#define CKM_DES3_CBC_PAD               0x00000136UL
+#define CKM_DES3_CMAC_GENERAL          0x00000137UL
+#define CKM_DES3_CMAC                  0x00000138UL
+#define CKM_CDMF_KEY_GEN               0x00000140UL
+#define CKM_CDMF_ECB                   0x00000141UL
+#define CKM_CDMF_CBC                   0x00000142UL
+#define CKM_CDMF_MAC                   0x00000143UL
+#define CKM_CDMF_MAC_GENERAL           0x00000144UL
+#define CKM_CDMF_CBC_PAD               0x00000145UL
+
+#define CKM_DES_OFB64                  0x00000150UL
+#define CKM_DES_OFB8                   0x00000151UL
+#define CKM_DES_CFB64                  0x00000152UL
+#define CKM_DES_CFB8                   0x00000153UL
+
+#define CKM_MD2                        0x00000200UL
+
+#define CKM_MD2_HMAC                   0x00000201UL
+#define CKM_MD2_HMAC_GENERAL           0x00000202UL
+
+#define CKM_MD5                        0x00000210UL
+
+#define CKM_MD5_HMAC                   0x00000211UL
+#define CKM_MD5_HMAC_GENERAL           0x00000212UL
+
+#define CKM_SHA_1                      0x00000220UL
+
+#define CKM_SHA_1_HMAC                 0x00000221UL
+#define CKM_SHA_1_HMAC_GENERAL         0x00000222UL
+
+#define CKM_RIPEMD128                  0x00000230UL
+#define CKM_RIPEMD128_HMAC             0x00000231UL
+#define CKM_RIPEMD128_HMAC_GENERAL     0x00000232UL
+#define CKM_RIPEMD160                  0x00000240UL
+#define CKM_RIPEMD160_HMAC             0x00000241UL
+#define CKM_RIPEMD160_HMAC_GENERAL     0x00000242UL
+
+#define CKM_SHA256                     0x00000250UL
+#define CKM_SHA256_HMAC                0x00000251UL
+#define CKM_SHA256_HMAC_GENERAL        0x00000252UL
+#define CKM_SHA224                     0x00000255UL
+#define CKM_SHA224_HMAC                0x00000256UL
+#define CKM_SHA224_HMAC_GENERAL        0x00000257UL
+#define CKM_SHA384                     0x00000260UL
+#define CKM_SHA384_HMAC                0x00000261UL
+#define CKM_SHA384_HMAC_GENERAL        0x00000262UL
+#define CKM_SHA512                     0x00000270UL
+#define CKM_SHA512_HMAC                0x00000271UL
+#define CKM_SHA512_HMAC_GENERAL        0x00000272UL
+#define CKM_SECURID_KEY_GEN            0x00000280UL
+#define CKM_SECURID                    0x00000282UL
+#define CKM_HOTP_KEY_GEN               0x00000290UL
+#define CKM_HOTP                       0x00000291UL
+#define CKM_ACTI                       0x000002A0UL
+#define CKM_ACTI_KEY_GEN               0x000002A1UL
+
+#define CKM_CAST_KEY_GEN               0x00000300UL
+#define CKM_CAST_ECB                   0x00000301UL
+#define CKM_CAST_CBC                   0x00000302UL
+#define CKM_CAST_MAC                   0x00000303UL
+#define CKM_CAST_MAC_GENERAL           0x00000304UL
+#define CKM_CAST_CBC_PAD               0x00000305UL
+#define CKM_CAST3_KEY_GEN              0x00000310UL
+#define CKM_CAST3_ECB                  0x00000311UL
+#define CKM_CAST3_CBC                  0x00000312UL
+#define CKM_CAST3_MAC                  0x00000313UL
+#define CKM_CAST3_MAC_GENERAL          0x00000314UL
+#define CKM_CAST3_CBC_PAD              0x00000315UL
+/* Note that CAST128 and CAST5 are the same algorithm */
+#define CKM_CAST5_KEY_GEN              0x00000320UL
+#define CKM_CAST128_KEY_GEN            0x00000320UL
+#define CKM_CAST5_ECB                  0x00000321UL
+#define CKM_CAST128_ECB                0x00000321UL
+#define CKM_CAST5_CBC                  0x00000322UL /* Deprecated */
+#define CKM_CAST128_CBC                0x00000322UL
+#define CKM_CAST5_MAC                  0x00000323UL /* Deprecated */
+#define CKM_CAST128_MAC                0x00000323UL
+#define CKM_CAST5_MAC_GENERAL          0x00000324UL /* Deprecated */
+#define CKM_CAST128_MAC_GENERAL        0x00000324UL
+#define CKM_CAST5_CBC_PAD              0x00000325UL /* Deprecated */
+#define CKM_CAST128_CBC_PAD            0x00000325UL
+#define CKM_RC5_KEY_GEN                0x00000330UL
+#define CKM_RC5_ECB                    0x00000331UL
+#define CKM_RC5_CBC                    0x00000332UL
+#define CKM_RC5_MAC                    0x00000333UL
+#define CKM_RC5_MAC_GENERAL            0x00000334UL
+#define CKM_RC5_CBC_PAD                0x00000335UL
+#define CKM_IDEA_KEY_GEN               0x00000340UL
+#define CKM_IDEA_ECB                   0x00000341UL
+#define CKM_IDEA_CBC                   0x00000342UL
+#define CKM_IDEA_MAC                   0x00000343UL
+#define CKM_IDEA_MAC_GENERAL           0x00000344UL
+#define CKM_IDEA_CBC_PAD               0x00000345UL
+#define CKM_GENERIC_SECRET_KEY_GEN     0x00000350UL
+#define CKM_CONCATENATE_BASE_AND_KEY   0x00000360UL
+#define CKM_CONCATENATE_BASE_AND_DATA  0x00000362UL
+#define CKM_CONCATENATE_DATA_AND_BASE  0x00000363UL
+#define CKM_XOR_BASE_AND_DATA          0x00000364UL
+#define CKM_EXTRACT_KEY_FROM_KEY       0x00000365UL
+#define CKM_SSL3_PRE_MASTER_KEY_GEN    0x00000370UL
+#define CKM_SSL3_MASTER_KEY_DERIVE     0x00000371UL
+#define CKM_SSL3_KEY_AND_MAC_DERIVE    0x00000372UL
+
+#define CKM_SSL3_MASTER_KEY_DERIVE_DH  0x00000373UL
+#define CKM_TLS_PRE_MASTER_KEY_GEN     0x00000374UL
+#define CKM_TLS_MASTER_KEY_DERIVE      0x00000375UL
+#define CKM_TLS_KEY_AND_MAC_DERIVE     0x00000376UL
+#define CKM_TLS_MASTER_KEY_DERIVE_DH   0x00000377UL
+
+#define CKM_TLS_PRF                    0x00000378UL
+
+#define CKM_SSL3_MD5_MAC               0x00000380UL
+#define CKM_SSL3_SHA1_MAC              0x00000381UL
+#define CKM_MD5_KEY_DERIVATION         0x00000390UL
+#define CKM_MD2_KEY_DERIVATION         0x00000391UL
+#define CKM_SHA1_KEY_DERIVATION        0x00000392UL
+
+#define CKM_SHA256_KEY_DERIVATION      0x00000393UL
+#define CKM_SHA384_KEY_DERIVATION      0x00000394UL
+#define CKM_SHA512_KEY_DERIVATION      0x00000395UL
+#define CKM_SHA224_KEY_DERIVATION      0x00000396UL
+
+#define CKM_PBE_MD2_DES_CBC            0x000003A0UL
+#define CKM_PBE_MD5_DES_CBC            0x000003A1UL
+#define CKM_PBE_MD5_CAST_CBC           0x000003A2UL
+#define CKM_PBE_MD5_CAST3_CBC          0x000003A3UL
+#define CKM_PBE_MD5_CAST5_CBC          0x000003A4UL /* Deprecated */
+#define CKM_PBE_MD5_CAST128_CBC        0x000003A4UL
+#define CKM_PBE_SHA1_CAST5_CBC         0x000003A5UL /* Deprecated */
+#define CKM_PBE_SHA1_CAST128_CBC       0x000003A5UL
+#define CKM_PBE_SHA1_RC4_128           0x000003A6UL
+#define CKM_PBE_SHA1_RC4_40            0x000003A7UL
+#define CKM_PBE_SHA1_DES3_EDE_CBC      0x000003A8UL
+#define CKM_PBE_SHA1_DES2_EDE_CBC      0x000003A9UL
+#define CKM_PBE_SHA1_RC2_128_CBC       0x000003AAUL
+#define CKM_PBE_SHA1_RC2_40_CBC        0x000003ABUL
+
+#define CKM_PKCS5_PBKD2                0x000003B0UL
+
+#define CKM_PBA_SHA1_WITH_SHA1_HMAC    0x000003C0UL
+
+#define CKM_WTLS_PRE_MASTER_KEY_GEN         0x000003D0UL
+#define CKM_WTLS_MASTER_KEY_DERIVE          0x000003D1UL
+#define CKM_WTLS_MASTER_KEY_DERIVE_DH_ECC   0x000003D2UL
+#define CKM_WTLS_PRF                        0x000003D3UL
+#define CKM_WTLS_SERVER_KEY_AND_MAC_DERIVE  0x000003D4UL
+#define CKM_WTLS_CLIENT_KEY_AND_MAC_DERIVE  0x000003D5UL
+
+#define CKM_TLS10_MAC_SERVER                0x000003D6UL
+#define CKM_TLS10_MAC_CLIENT                0x000003D7UL
+#define CKM_TLS12_MAC                       0x000003D8UL
+#define CKM_TLS12_KDF                       0x000003D9UL
+#define CKM_TLS12_MASTER_KEY_DERIVE         0x000003E0UL
+#define CKM_TLS12_KEY_AND_MAC_DERIVE        0x000003E1UL
+#define CKM_TLS12_MASTER_KEY_DERIVE_DH      0x000003E2UL
+#define CKM_TLS12_KEY_SAFE_DERIVE           0x000003E3UL
+#define CKM_TLS_MAC                         0x000003E4UL
+#define CKM_TLS_KDF                         0x000003E5UL
+
+#define CKM_KEY_WRAP_LYNKS             0x00000400UL
+#define CKM_KEY_WRAP_SET_OAEP          0x00000401UL
+
+#define CKM_CMS_SIG                    0x00000500UL
+#define CKM_KIP_DERIVE                 0x00000510UL
+#define CKM_KIP_WRAP                   0x00000511UL
+#define CKM_KIP_MAC                    0x00000512UL
+
+#define CKM_CAMELLIA_KEY_GEN           0x00000550UL
+#define CKM_CAMELLIA_ECB               0x00000551UL
+#define CKM_CAMELLIA_CBC               0x00000552UL
+#define CKM_CAMELLIA_MAC               0x00000553UL
+#define CKM_CAMELLIA_MAC_GENERAL       0x00000554UL
+#define CKM_CAMELLIA_CBC_PAD           0x00000555UL
+#define CKM_CAMELLIA_ECB_ENCRYPT_DATA  0x00000556UL
+#define CKM_CAMELLIA_CBC_ENCRYPT_DATA  0x00000557UL
+#define CKM_CAMELLIA_CTR               0x00000558UL
+
+#define CKM_ARIA_KEY_GEN               0x00000560UL
+#define CKM_ARIA_ECB                   0x00000561UL
+#define CKM_ARIA_CBC                   0x00000562UL
+#define CKM_ARIA_MAC                   0x00000563UL
+#define CKM_ARIA_MAC_GENERAL           0x00000564UL
+#define CKM_ARIA_CBC_PAD               0x00000565UL
+#define CKM_ARIA_ECB_ENCRYPT_DATA      0x00000566UL
+#define CKM_ARIA_CBC_ENCRYPT_DATA      0x00000567UL
+
+#define CKM_SEED_KEY_GEN               0x00000650UL
+#define CKM_SEED_ECB                   0x00000651UL
+#define CKM_SEED_CBC                   0x00000652UL
+#define CKM_SEED_MAC                   0x00000653UL
+#define CKM_SEED_MAC_GENERAL           0x00000654UL
+#define CKM_SEED_CBC_PAD               0x00000655UL
+#define CKM_SEED_ECB_ENCRYPT_DATA      0x00000656UL
+#define CKM_SEED_CBC_ENCRYPT_DATA      0x00000657UL
+
+#define CKM_SKIPJACK_KEY_GEN           0x00001000UL
+#define CKM_SKIPJACK_ECB64             0x00001001UL
+#define CKM_SKIPJACK_CBC64             0x00001002UL
+#define CKM_SKIPJACK_OFB64             0x00001003UL
+#define CKM_SKIPJACK_CFB64             0x00001004UL
+#define CKM_SKIPJACK_CFB32             0x00001005UL
+#define CKM_SKIPJACK_CFB16             0x00001006UL
+#define CKM_SKIPJACK_CFB8              0x00001007UL
+#define CKM_SKIPJACK_WRAP              0x00001008UL
+#define CKM_SKIPJACK_PRIVATE_WRAP      0x00001009UL
+#define CKM_SKIPJACK_RELAYX            0x0000100aUL
+#define CKM_KEA_KEY_PAIR_GEN           0x00001010UL
+#define CKM_KEA_KEY_DERIVE             0x00001011UL
+#define CKM_KEA_DERIVE                 0x00001012UL
+#define CKM_FORTEZZA_TIMESTAMP         0x00001020UL
+#define CKM_BATON_KEY_GEN              0x00001030UL
+#define CKM_BATON_ECB128               0x00001031UL
+#define CKM_BATON_ECB96                0x00001032UL
+#define CKM_BATON_CBC128               0x00001033UL
+#define CKM_BATON_COUNTER              0x00001034UL
+#define CKM_BATON_SHUFFLE              0x00001035UL
+#define CKM_BATON_WRAP                 0x00001036UL
+
+#define CKM_ECDSA_KEY_PAIR_GEN         0x00001040UL /* Deprecated */
+#define CKM_EC_KEY_PAIR_GEN            0x00001040UL
+
+#define CKM_ECDSA                      0x00001041UL
+#define CKM_ECDSA_SHA1                 0x00001042UL
+#define CKM_ECDSA_SHA224               0x00001043UL
+#define CKM_ECDSA_SHA256               0x00001044UL
+#define CKM_ECDSA_SHA384               0x00001045UL
+#define CKM_ECDSA_SHA512               0x00001046UL
+
+#define CKM_ECDH1_DERIVE               0x00001050UL
+#define CKM_ECDH1_COFACTOR_DERIVE      0x00001051UL
+#define CKM_ECMQV_DERIVE               0x00001052UL
+
+#define CKM_ECDH_AES_KEY_WRAP          0x00001053UL
+#define CKM_RSA_AES_KEY_WRAP           0x00001054UL
+
+#define CKM_JUNIPER_KEY_GEN            0x00001060UL
+#define CKM_JUNIPER_ECB128             0x00001061UL
+#define CKM_JUNIPER_CBC128             0x00001062UL
+#define CKM_JUNIPER_COUNTER            0x00001063UL
+#define CKM_JUNIPER_SHUFFLE            0x00001064UL
+#define CKM_JUNIPER_WRAP               0x00001065UL
+#define CKM_FASTHASH                   0x00001070UL
+
+#define CKM_AES_KEY_GEN                0x00001080UL
+#define CKM_AES_ECB                    0x00001081UL
+#define CKM_AES_CBC                    0x00001082UL
+#define CKM_AES_MAC                    0x00001083UL
+#define CKM_AES_MAC_GENERAL            0x00001084UL
+#define CKM_AES_CBC_PAD                0x00001085UL
+#define CKM_AES_CTR                    0x00001086UL
+#define CKM_AES_GCM                    0x00001087UL
+#define CKM_AES_CCM                    0x00001088UL
+#define CKM_AES_CTS                    0x00001089UL
+#define CKM_AES_CMAC                   0x0000108AUL
+#define CKM_AES_CMAC_GENERAL           0x0000108BUL
+
+#define CKM_AES_XCBC_MAC               0x0000108CUL
+#define CKM_AES_XCBC_MAC_96            0x0000108DUL
+#define CKM_AES_GMAC                   0x0000108EUL
+
+#define CKM_BLOWFISH_KEY_GEN           0x00001090UL
+#define CKM_BLOWFISH_CBC               0x00001091UL
+#define CKM_TWOFISH_KEY_GEN            0x00001092UL
+#define CKM_TWOFISH_CBC                0x00001093UL
+#define CKM_BLOWFISH_CBC_PAD           0x00001094UL
+#define CKM_TWOFISH_CBC_PAD            0x00001095UL
+
+#define CKM_DES_ECB_ENCRYPT_DATA       0x00001100UL
+#define CKM_DES_CBC_ENCRYPT_DATA       0x00001101UL
+#define CKM_DES3_ECB_ENCRYPT_DATA      0x00001102UL
+#define CKM_DES3_CBC_ENCRYPT_DATA      0x00001103UL
+#define CKM_AES_ECB_ENCRYPT_DATA       0x00001104UL
+#define CKM_AES_CBC_ENCRYPT_DATA       0x00001105UL
+
+#define CKM_GOSTR3410_KEY_PAIR_GEN     0x00001200UL
+#define CKM_GOSTR3410                  0x00001201UL
+#define CKM_GOSTR3410_WITH_GOSTR3411   0x00001202UL
+#define CKM_GOSTR3410_KEY_WRAP         0x00001203UL
+#define CKM_GOSTR3410_DERIVE           0x00001204UL
+#define CKM_GOSTR3411                  0x00001210UL
+#define CKM_GOSTR3411_HMAC             0x00001211UL
+#define CKM_GOST28147_KEY_GEN          0x00001220UL
+#define CKM_GOST28147_ECB              0x00001221UL
+#define CKM_GOST28147                  0x00001222UL
+#define CKM_GOST28147_MAC              0x00001223UL
+#define CKM_GOST28147_KEY_WRAP         0x00001224UL
+
+#define CKM_DSA_PARAMETER_GEN          0x00002000UL
+#define CKM_DH_PKCS_PARAMETER_GEN      0x00002001UL
+#define CKM_X9_42_DH_PARAMETER_GEN     0x00002002UL
+#define CKM_DSA_PROBABLISTIC_PARAMETER_GEN    0x00002003UL
+#define CKM_DSA_SHAWE_TAYLOR_PARAMETER_GEN    0x00002004UL
+
+#define CKM_AES_OFB                    0x00002104UL
+#define CKM_AES_CFB64                  0x00002105UL
+#define CKM_AES_CFB8                   0x00002106UL
+#define CKM_AES_CFB128                 0x00002107UL
+
+#define CKM_AES_CFB1                   0x00002108UL
+#define CKM_AES_KEY_WRAP               0x00002109UL     /* WAS: 0x00001090 */
+#define CKM_AES_KEY_WRAP_PAD           0x0000210AUL     /* WAS: 0x00001091 */
+
+#define CKM_RSA_PKCS_TPM_1_1           0x00004001UL
+#define CKM_RSA_PKCS_OAEP_TPM_1_1      0x00004002UL
+
+#define CKM_VENDOR_DEFINED             0x80000000UL
+
+typedef CK_MECHANISM_TYPE CK_PTR CK_MECHANISM_TYPE_PTR;
+
+
+/* CK_MECHANISM is a structure that specifies a particular
+ * mechanism
+ */
+typedef struct CK_MECHANISM {
+  CK_MECHANISM_TYPE mechanism;
+  CK_VOID_PTR       pParameter;
+  CK_ULONG          ulParameterLen;  /* in bytes */
+} CK_MECHANISM;
+
+typedef CK_MECHANISM CK_PTR CK_MECHANISM_PTR;
+
+
+/* CK_MECHANISM_INFO provides information about a particular
+ * mechanism
+ */
+typedef struct CK_MECHANISM_INFO {
+    CK_ULONG    ulMinKeySize;
+    CK_ULONG    ulMaxKeySize;
+    CK_FLAGS    flags;
+} CK_MECHANISM_INFO;
+
+/* The flags are defined as follows:
+ *      Bit Flag               Mask          Meaning */
+#define CKF_HW                 0x00000001UL  /* performed by HW */
+
+/* Specify whether or not a mechanism can be used for a particular task */
+#define CKF_ENCRYPT            0x00000100UL
+#define CKF_DECRYPT            0x00000200UL
+#define CKF_DIGEST             0x00000400UL
+#define CKF_SIGN               0x00000800UL
+#define CKF_SIGN_RECOVER       0x00001000UL
+#define CKF_VERIFY             0x00002000UL
+#define CKF_VERIFY_RECOVER     0x00004000UL
+#define CKF_GENERATE           0x00008000UL
+#define CKF_GENERATE_KEY_PAIR  0x00010000UL
+#define CKF_WRAP               0x00020000UL
+#define CKF_UNWRAP             0x00040000UL
+#define CKF_DERIVE             0x00080000UL
+
+/* Describe a token's EC capabilities not available in mechanism
+ * information.
+ */
+#define CKF_EC_F_P             0x00100000UL
+#define CKF_EC_F_2M            0x00200000UL
+#define CKF_EC_ECPARAMETERS    0x00400000UL
+#define CKF_EC_NAMEDCURVE      0x00800000UL
+#define CKF_EC_UNCOMPRESS      0x01000000UL
+#define CKF_EC_COMPRESS        0x02000000UL
+
+#define CKF_EXTENSION          0x80000000UL
+
+typedef CK_MECHANISM_INFO CK_PTR CK_MECHANISM_INFO_PTR;
+
+/* CK_RV is a value that identifies the return value of a
+ * Cryptoki function
+ */
+typedef CK_ULONG          CK_RV;
+
+#define CKR_OK                                0x00000000UL
+#define CKR_CANCEL                            0x00000001UL
+#define CKR_HOST_MEMORY                       0x00000002UL
+#define CKR_SLOT_ID_INVALID                   0x00000003UL
+
+#define CKR_GENERAL_ERROR                     0x00000005UL
+#define CKR_FUNCTION_FAILED                   0x00000006UL
+
+#define CKR_ARGUMENTS_BAD                     0x00000007UL
+#define CKR_NO_EVENT                          0x00000008UL
+#define CKR_NEED_TO_CREATE_THREADS            0x00000009UL
+#define CKR_CANT_LOCK                         0x0000000AUL
+
+#define CKR_ATTRIBUTE_READ_ONLY               0x00000010UL
+#define CKR_ATTRIBUTE_SENSITIVE               0x00000011UL
+#define CKR_ATTRIBUTE_TYPE_INVALID            0x00000012UL
+#define CKR_ATTRIBUTE_VALUE_INVALID           0x00000013UL
+
+#define CKR_ACTION_PROHIBITED                 0x0000001BUL
+
+#define CKR_DATA_INVALID                      0x00000020UL
+#define CKR_DATA_LEN_RANGE                    0x00000021UL
+#define CKR_DEVICE_ERROR                      0x00000030UL
+#define CKR_DEVICE_MEMORY                     0x00000031UL
+#define CKR_DEVICE_REMOVED                    0x00000032UL
+#define CKR_ENCRYPTED_DATA_INVALID            0x00000040UL
+#define CKR_ENCRYPTED_DATA_LEN_RANGE          0x00000041UL
+#define CKR_FUNCTION_CANCELED                 0x00000050UL
+#define CKR_FUNCTION_NOT_PARALLEL             0x00000051UL
+
+#define CKR_FUNCTION_NOT_SUPPORTED            0x00000054UL
+
+#define CKR_KEY_HANDLE_INVALID                0x00000060UL
+
+#define CKR_KEY_SIZE_RANGE                    0x00000062UL
+#define CKR_KEY_TYPE_INCONSISTENT             0x00000063UL
+
+#define CKR_KEY_NOT_NEEDED                    0x00000064UL
+#define CKR_KEY_CHANGED                       0x00000065UL
+#define CKR_KEY_NEEDED                        0x00000066UL
+#define CKR_KEY_INDIGESTIBLE                  0x00000067UL
+#define CKR_KEY_FUNCTION_NOT_PERMITTED        0x00000068UL
+#define CKR_KEY_NOT_WRAPPABLE                 0x00000069UL
+#define CKR_KEY_UNEXTRACTABLE                 0x0000006AUL
+
+#define CKR_MECHANISM_INVALID                 0x00000070UL
+#define CKR_MECHANISM_PARAM_INVALID           0x00000071UL
+
+#define CKR_OBJECT_HANDLE_INVALID             0x00000082UL
+#define CKR_OPERATION_ACTIVE                  0x00000090UL
+#define CKR_OPERATION_NOT_INITIALIZED         0x00000091UL
+#define CKR_PIN_INCORRECT                     0x000000A0UL
+#define CKR_PIN_INVALID                       0x000000A1UL
+#define CKR_PIN_LEN_RANGE                     0x000000A2UL
+
+#define CKR_PIN_EXPIRED                       0x000000A3UL
+#define CKR_PIN_LOCKED                        0x000000A4UL
+
+#define CKR_SESSION_CLOSED                    0x000000B0UL
+#define CKR_SESSION_COUNT                     0x000000B1UL
+#define CKR_SESSION_HANDLE_INVALID            0x000000B3UL
+#define CKR_SESSION_PARALLEL_NOT_SUPPORTED    0x000000B4UL
+#define CKR_SESSION_READ_ONLY                 0x000000B5UL
+#define CKR_SESSION_EXISTS                    0x000000B6UL
+
+#define CKR_SESSION_READ_ONLY_EXISTS          0x000000B7UL
+#define CKR_SESSION_READ_WRITE_SO_EXISTS      0x000000B8UL
+
+#define CKR_SIGNATURE_INVALID                 0x000000C0UL
+#define CKR_SIGNATURE_LEN_RANGE               0x000000C1UL
+#define CKR_TEMPLATE_INCOMPLETE               0x000000D0UL
+#define CKR_TEMPLATE_INCONSISTENT             0x000000D1UL
+#define CKR_TOKEN_NOT_PRESENT                 0x000000E0UL
+#define CKR_TOKEN_NOT_RECOGNIZED              0x000000E1UL
+#define CKR_TOKEN_WRITE_PROTECTED             0x000000E2UL
+#define CKR_UNWRAPPING_KEY_HANDLE_INVALID     0x000000F0UL
+#define CKR_UNWRAPPING_KEY_SIZE_RANGE         0x000000F1UL
+#define CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT  0x000000F2UL
+#define CKR_USER_ALREADY_LOGGED_IN            0x00000100UL
+#define CKR_USER_NOT_LOGGED_IN                0x00000101UL
+#define CKR_USER_PIN_NOT_INITIALIZED          0x00000102UL
+#define CKR_USER_TYPE_INVALID                 0x00000103UL
+
+#define CKR_USER_ANOTHER_ALREADY_LOGGED_IN    0x00000104UL
+#define CKR_USER_TOO_MANY_TYPES               0x00000105UL
+
+#define CKR_WRAPPED_KEY_INVALID               0x00000110UL
+#define CKR_WRAPPED_KEY_LEN_RANGE             0x00000112UL
+#define CKR_WRAPPING_KEY_HANDLE_INVALID       0x00000113UL
+#define CKR_WRAPPING_KEY_SIZE_RANGE           0x00000114UL
+#define CKR_WRAPPING_KEY_TYPE_INCONSISTENT    0x00000115UL
+#define CKR_RANDOM_SEED_NOT_SUPPORTED         0x00000120UL
+
+#define CKR_RANDOM_NO_RNG                     0x00000121UL
+
+#define CKR_DOMAIN_PARAMS_INVALID             0x00000130UL
+
+#define CKR_CURVE_NOT_SUPPORTED               0x00000140UL
+
+#define CKR_BUFFER_TOO_SMALL                  0x00000150UL
+#define CKR_SAVED_STATE_INVALID               0x00000160UL
+#define CKR_INFORMATION_SENSITIVE             0x00000170UL
+#define CKR_STATE_UNSAVEABLE                  0x00000180UL
+
+#define CKR_CRYPTOKI_NOT_INITIALIZED          0x00000190UL
+#define CKR_CRYPTOKI_ALREADY_INITIALIZED      0x00000191UL
+#define CKR_MUTEX_BAD                         0x000001A0UL
+#define CKR_MUTEX_NOT_LOCKED                  0x000001A1UL
+
+#define CKR_NEW_PIN_MODE                      0x000001B0UL
+#define CKR_NEXT_OTP                          0x000001B1UL
+
+#define CKR_EXCEEDED_MAX_ITERATIONS           0x000001B5UL
+#define CKR_FIPS_SELF_TEST_FAILED             0x000001B6UL
+#define CKR_LIBRARY_LOAD_FAILED               0x000001B7UL
+#define CKR_PIN_TOO_WEAK                      0x000001B8UL
+#define CKR_PUBLIC_KEY_INVALID                0x000001B9UL
+
+#define CKR_FUNCTION_REJECTED                 0x00000200UL
+
+#define CKR_VENDOR_DEFINED                    0x80000000UL
+
+
+/* CK_NOTIFY is an application callback that processes events */
+typedef CK_CALLBACK_FUNCTION(CK_RV, CK_NOTIFY)(
+  CK_SESSION_HANDLE hSession,     /* the session's handle */
+  CK_NOTIFICATION   event,
+  CK_VOID_PTR       pApplication  /* passed to C_OpenSession */
+);
+
+
+/* CK_FUNCTION_LIST is a structure holding a Cryptoki spec
+ * version and pointers of appropriate types to all the
+ * Cryptoki functions
+ */
+typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;
+
+typedef CK_FUNCTION_LIST CK_PTR CK_FUNCTION_LIST_PTR;
+
+typedef CK_FUNCTION_LIST_PTR CK_PTR CK_FUNCTION_LIST_PTR_PTR;
+
+
+/* CK_CREATEMUTEX is an application callback for creating a
+ * mutex object
+ */
+typedef CK_CALLBACK_FUNCTION(CK_RV, CK_CREATEMUTEX)(
+  CK_VOID_PTR_PTR ppMutex  /* location to receive ptr to mutex */
+);
+
+
+/* CK_DESTROYMUTEX is an application callback for destroying a
+ * mutex object
+ */
+typedef CK_CALLBACK_FUNCTION(CK_RV, CK_DESTROYMUTEX)(
+  CK_VOID_PTR pMutex  /* pointer to mutex */
+);
+
+
+/* CK_LOCKMUTEX is an application callback for locking a mutex */
+typedef CK_CALLBACK_FUNCTION(CK_RV, CK_LOCKMUTEX)(
+  CK_VOID_PTR pMutex  /* pointer to mutex */
+);
+
+
+/* CK_UNLOCKMUTEX is an application callback for unlocking a
+ * mutex
+ */
+typedef CK_CALLBACK_FUNCTION(CK_RV, CK_UNLOCKMUTEX)(
+  CK_VOID_PTR pMutex  /* pointer to mutex */
+);
+
+
+/* CK_C_INITIALIZE_ARGS provides the optional arguments to
+ * C_Initialize
+ */
+typedef struct CK_C_INITIALIZE_ARGS {
+  CK_CREATEMUTEX CreateMutex;
+  CK_DESTROYMUTEX DestroyMutex;
+  CK_LOCKMUTEX LockMutex;
+  CK_UNLOCKMUTEX UnlockMutex;
+  CK_FLAGS flags;
+  CK_VOID_PTR pReserved;
+} CK_C_INITIALIZE_ARGS;
+
+/* flags: bit flags that provide capabilities of the slot
+ *      Bit Flag                           Mask       Meaning
+ */
+#define CKF_LIBRARY_CANT_CREATE_OS_THREADS 0x00000001UL
+#define CKF_OS_LOCKING_OK                  0x00000002UL
+
+typedef CK_C_INITIALIZE_ARGS CK_PTR CK_C_INITIALIZE_ARGS_PTR;
+
+
+/* additional flags for parameters to functions */
+
+/* CKF_DONT_BLOCK is for the function C_WaitForSlotEvent */
+#define CKF_DONT_BLOCK     1
+
+/* CK_RSA_PKCS_MGF_TYPE  is used to indicate the Message
+ * Generation Function (MGF) applied to a message block when
+ * formatting a message block for the PKCS #1 OAEP encryption
+ * scheme.
+ */
+typedef CK_ULONG CK_RSA_PKCS_MGF_TYPE;
+
+typedef CK_RSA_PKCS_MGF_TYPE CK_PTR CK_RSA_PKCS_MGF_TYPE_PTR;
+
+/* The following MGFs are defined */
+#define CKG_MGF1_SHA1         0x00000001UL
+#define CKG_MGF1_SHA256       0x00000002UL
+#define CKG_MGF1_SHA384       0x00000003UL
+#define CKG_MGF1_SHA512       0x00000004UL
+#define CKG_MGF1_SHA224       0x00000005UL
+
+/* CK_RSA_PKCS_OAEP_SOURCE_TYPE  is used to indicate the source
+ * of the encoding parameter when formatting a message block
+ * for the PKCS #1 OAEP encryption scheme.
+ */
+typedef CK_ULONG CK_RSA_PKCS_OAEP_SOURCE_TYPE;
+
+typedef CK_RSA_PKCS_OAEP_SOURCE_TYPE CK_PTR CK_RSA_PKCS_OAEP_SOURCE_TYPE_PTR;
+
+/* The following encoding parameter sources are defined */
+#define CKZ_DATA_SPECIFIED    0x00000001UL
+
+/* CK_RSA_PKCS_OAEP_PARAMS provides the parameters to the
+ * CKM_RSA_PKCS_OAEP mechanism.
+ */
+typedef struct CK_RSA_PKCS_OAEP_PARAMS {
+        CK_MECHANISM_TYPE hashAlg;
+        CK_RSA_PKCS_MGF_TYPE mgf;
+        CK_RSA_PKCS_OAEP_SOURCE_TYPE source;
+        CK_VOID_PTR pSourceData;
+        CK_ULONG ulSourceDataLen;
+} CK_RSA_PKCS_OAEP_PARAMS;
+
+typedef CK_RSA_PKCS_OAEP_PARAMS CK_PTR CK_RSA_PKCS_OAEP_PARAMS_PTR;
+
+/* CK_RSA_PKCS_PSS_PARAMS provides the parameters to the
+ * CKM_RSA_PKCS_PSS mechanism(s).
+ */
+typedef struct CK_RSA_PKCS_PSS_PARAMS {
+        CK_MECHANISM_TYPE    hashAlg;
+        CK_RSA_PKCS_MGF_TYPE mgf;
+        CK_ULONG             sLen;
+} CK_RSA_PKCS_PSS_PARAMS;
+
+typedef CK_RSA_PKCS_PSS_PARAMS CK_PTR CK_RSA_PKCS_PSS_PARAMS_PTR;
+
+typedef CK_ULONG CK_EC_KDF_TYPE;
+
+/* The following EC Key Derivation Functions are defined */
+#define CKD_NULL                 0x00000001UL
+#define CKD_SHA1_KDF             0x00000002UL
+
+/* The following X9.42 DH key derivation functions are defined */
+#define CKD_SHA1_KDF_ASN1        0x00000003UL
+#define CKD_SHA1_KDF_CONCATENATE 0x00000004UL
+#define CKD_SHA224_KDF           0x00000005UL
+#define CKD_SHA256_KDF           0x00000006UL
+#define CKD_SHA384_KDF           0x00000007UL
+#define CKD_SHA512_KDF           0x00000008UL
+#define CKD_CPDIVERSIFY_KDF      0x00000009UL
+
+
+/* CK_ECDH1_DERIVE_PARAMS provides the parameters to the
+ * CKM_ECDH1_DERIVE and CKM_ECDH1_COFACTOR_DERIVE mechanisms,
+ * where each party contributes one key pair.
+ */
+typedef struct CK_ECDH1_DERIVE_PARAMS {
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+} CK_ECDH1_DERIVE_PARAMS;
+
+typedef CK_ECDH1_DERIVE_PARAMS CK_PTR CK_ECDH1_DERIVE_PARAMS_PTR;
+
+/*
+ * CK_ECDH2_DERIVE_PARAMS provides the parameters to the
+ * CKM_ECMQV_DERIVE mechanism, where each party contributes two key pairs.
+ */
+typedef struct CK_ECDH2_DERIVE_PARAMS {
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+} CK_ECDH2_DERIVE_PARAMS;
+
+typedef CK_ECDH2_DERIVE_PARAMS CK_PTR CK_ECDH2_DERIVE_PARAMS_PTR;
+
+typedef struct CK_ECMQV_DERIVE_PARAMS {
+  CK_EC_KDF_TYPE kdf;
+  CK_ULONG ulSharedDataLen;
+  CK_BYTE_PTR pSharedData;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+  CK_OBJECT_HANDLE publicKey;
+} CK_ECMQV_DERIVE_PARAMS;
+
+typedef CK_ECMQV_DERIVE_PARAMS CK_PTR CK_ECMQV_DERIVE_PARAMS_PTR;
+
+/* Typedefs and defines for the CKM_X9_42_DH_KEY_PAIR_GEN and the
+ * CKM_X9_42_DH_PARAMETER_GEN mechanisms
+ */
+typedef CK_ULONG CK_X9_42_DH_KDF_TYPE;
+typedef CK_X9_42_DH_KDF_TYPE CK_PTR CK_X9_42_DH_KDF_TYPE_PTR;
+
+/* CK_X9_42_DH1_DERIVE_PARAMS provides the parameters to the
+ * CKM_X9_42_DH_DERIVE key derivation mechanism, where each party
+ * contributes one key pair
+ */
+typedef struct CK_X9_42_DH1_DERIVE_PARAMS {
+  CK_X9_42_DH_KDF_TYPE kdf;
+  CK_ULONG ulOtherInfoLen;
+  CK_BYTE_PTR pOtherInfo;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+} CK_X9_42_DH1_DERIVE_PARAMS;
+
+typedef struct CK_X9_42_DH1_DERIVE_PARAMS CK_PTR CK_X9_42_DH1_DERIVE_PARAMS_PTR;
+
+/* CK_X9_42_DH2_DERIVE_PARAMS provides the parameters to the
+ * CKM_X9_42_DH_HYBRID_DERIVE and CKM_X9_42_MQV_DERIVE key derivation
+ * mechanisms, where each party contributes two key pairs
+ */
+typedef struct CK_X9_42_DH2_DERIVE_PARAMS {
+  CK_X9_42_DH_KDF_TYPE kdf;
+  CK_ULONG ulOtherInfoLen;
+  CK_BYTE_PTR pOtherInfo;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+} CK_X9_42_DH2_DERIVE_PARAMS;
+
+typedef CK_X9_42_DH2_DERIVE_PARAMS CK_PTR CK_X9_42_DH2_DERIVE_PARAMS_PTR;
+
+typedef struct CK_X9_42_MQV_DERIVE_PARAMS {
+  CK_X9_42_DH_KDF_TYPE kdf;
+  CK_ULONG ulOtherInfoLen;
+  CK_BYTE_PTR pOtherInfo;
+  CK_ULONG ulPublicDataLen;
+  CK_BYTE_PTR pPublicData;
+  CK_ULONG ulPrivateDataLen;
+  CK_OBJECT_HANDLE hPrivateData;
+  CK_ULONG ulPublicDataLen2;
+  CK_BYTE_PTR pPublicData2;
+  CK_OBJECT_HANDLE publicKey;
+} CK_X9_42_MQV_DERIVE_PARAMS;
+
+typedef CK_X9_42_MQV_DERIVE_PARAMS CK_PTR CK_X9_42_MQV_DERIVE_PARAMS_PTR;
+
+/* CK_KEA_DERIVE_PARAMS provides the parameters to the
+ * CKM_KEA_DERIVE mechanism
+ */
+typedef struct CK_KEA_DERIVE_PARAMS {
+  CK_BBOOL      isSender;
+  CK_ULONG      ulRandomLen;
+  CK_BYTE_PTR   pRandomA;
+  CK_BYTE_PTR   pRandomB;
+  CK_ULONG      ulPublicDataLen;
+  CK_BYTE_PTR   pPublicData;
+} CK_KEA_DERIVE_PARAMS;
+
+typedef CK_KEA_DERIVE_PARAMS CK_PTR CK_KEA_DERIVE_PARAMS_PTR;
+
+
+/* CK_RC2_PARAMS provides the parameters to the CKM_RC2_ECB and
+ * CKM_RC2_MAC mechanisms.  An instance of CK_RC2_PARAMS just
+ * holds the effective keysize
+ */
+typedef CK_ULONG          CK_RC2_PARAMS;
+
+typedef CK_RC2_PARAMS CK_PTR CK_RC2_PARAMS_PTR;
+
+
+/* CK_RC2_CBC_PARAMS provides the parameters to the CKM_RC2_CBC
+ * mechanism
+ */
+typedef struct CK_RC2_CBC_PARAMS {
+  CK_ULONG      ulEffectiveBits;  /* effective bits (1-1024) */
+  CK_BYTE       iv[8];            /* IV for CBC mode */
+} CK_RC2_CBC_PARAMS;
+
+typedef CK_RC2_CBC_PARAMS CK_PTR CK_RC2_CBC_PARAMS_PTR;
+
+
+/* CK_RC2_MAC_GENERAL_PARAMS provides the parameters for the
+ * CKM_RC2_MAC_GENERAL mechanism
+ */
+typedef struct CK_RC2_MAC_GENERAL_PARAMS {
+  CK_ULONG      ulEffectiveBits;  /* effective bits (1-1024) */
+  CK_ULONG      ulMacLength;      /* Length of MAC in bytes */
+} CK_RC2_MAC_GENERAL_PARAMS;
+
+typedef CK_RC2_MAC_GENERAL_PARAMS CK_PTR \
+  CK_RC2_MAC_GENERAL_PARAMS_PTR;
+
+
+/* CK_RC5_PARAMS provides the parameters to the CKM_RC5_ECB and
+ * CKM_RC5_MAC mechanisms
+ */
+typedef struct CK_RC5_PARAMS {
+  CK_ULONG      ulWordsize;  /* wordsize in bits */
+  CK_ULONG      ulRounds;    /* number of rounds */
+} CK_RC5_PARAMS;
+
+typedef CK_RC5_PARAMS CK_PTR CK_RC5_PARAMS_PTR;
+
+
+/* CK_RC5_CBC_PARAMS provides the parameters to the CKM_RC5_CBC
+ * mechanism
+ */
+typedef struct CK_RC5_CBC_PARAMS {
+  CK_ULONG      ulWordsize;  /* wordsize in bits */
+  CK_ULONG      ulRounds;    /* number of rounds */
+  CK_BYTE_PTR   pIv;         /* pointer to IV */
+  CK_ULONG      ulIvLen;     /* length of IV in bytes */
+} CK_RC5_CBC_PARAMS;
+
+typedef CK_RC5_CBC_PARAMS CK_PTR CK_RC5_CBC_PARAMS_PTR;
+
+
+/* CK_RC5_MAC_GENERAL_PARAMS provides the parameters for the
+ * CKM_RC5_MAC_GENERAL mechanism
+ */
+typedef struct CK_RC5_MAC_GENERAL_PARAMS {
+  CK_ULONG      ulWordsize;   /* wordsize in bits */
+  CK_ULONG      ulRounds;     /* number of rounds */
+  CK_ULONG      ulMacLength;  /* Length of MAC in bytes */
+} CK_RC5_MAC_GENERAL_PARAMS;
+
+typedef CK_RC5_MAC_GENERAL_PARAMS CK_PTR \
+  CK_RC5_MAC_GENERAL_PARAMS_PTR;
+
+/* CK_MAC_GENERAL_PARAMS provides the parameters to most block
+ * ciphers' MAC_GENERAL mechanisms.  Its value is the length of
+ * the MAC
+ */
+typedef CK_ULONG          CK_MAC_GENERAL_PARAMS;
+
+typedef CK_MAC_GENERAL_PARAMS CK_PTR CK_MAC_GENERAL_PARAMS_PTR;
+
+typedef struct CK_DES_CBC_ENCRYPT_DATA_PARAMS {
+  CK_BYTE      iv[8];
+  CK_BYTE_PTR  pData;
+  CK_ULONG     length;
+} CK_DES_CBC_ENCRYPT_DATA_PARAMS;
+
+typedef CK_DES_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_DES_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS {
+  CK_BYTE      iv[16];
+  CK_BYTE_PTR  pData;
+  CK_ULONG     length;
+} CK_AES_CBC_ENCRYPT_DATA_PARAMS;
+
+typedef CK_AES_CBC_ENCRYPT_DATA_PARAMS CK_PTR CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+/* CK_SKIPJACK_PRIVATE_WRAP_PARAMS provides the parameters to the
+ * CKM_SKIPJACK_PRIVATE_WRAP mechanism
+ */
+typedef struct CK_SKIPJACK_PRIVATE_WRAP_PARAMS {
+  CK_ULONG      ulPasswordLen;
+  CK_BYTE_PTR   pPassword;
+  CK_ULONG      ulPublicDataLen;
+  CK_BYTE_PTR   pPublicData;
+  CK_ULONG      ulPAndGLen;
+  CK_ULONG      ulQLen;
+  CK_ULONG      ulRandomLen;
+  CK_BYTE_PTR   pRandomA;
+  CK_BYTE_PTR   pPrimeP;
+  CK_BYTE_PTR   pBaseG;
+  CK_BYTE_PTR   pSubprimeQ;
+} CK_SKIPJACK_PRIVATE_WRAP_PARAMS;
+
+typedef CK_SKIPJACK_PRIVATE_WRAP_PARAMS CK_PTR \
+  CK_SKIPJACK_PRIVATE_WRAP_PARAMS_PTR;
+
+
+/* CK_SKIPJACK_RELAYX_PARAMS provides the parameters to the
+ * CKM_SKIPJACK_RELAYX mechanism
+ */
+typedef struct CK_SKIPJACK_RELAYX_PARAMS {
+  CK_ULONG      ulOldWrappedXLen;
+  CK_BYTE_PTR   pOldWrappedX;
+  CK_ULONG      ulOldPasswordLen;
+  CK_BYTE_PTR   pOldPassword;
+  CK_ULONG      ulOldPublicDataLen;
+  CK_BYTE_PTR   pOldPublicData;
+  CK_ULONG      ulOldRandomLen;
+  CK_BYTE_PTR   pOldRandomA;
+  CK_ULONG      ulNewPasswordLen;
+  CK_BYTE_PTR   pNewPassword;
+  CK_ULONG      ulNewPublicDataLen;
+  CK_BYTE_PTR   pNewPublicData;
+  CK_ULONG      ulNewRandomLen;
+  CK_BYTE_PTR   pNewRandomA;
+} CK_SKIPJACK_RELAYX_PARAMS;
+
+typedef CK_SKIPJACK_RELAYX_PARAMS CK_PTR \
+  CK_SKIPJACK_RELAYX_PARAMS_PTR;
+
+
+typedef struct CK_PBE_PARAMS {
+  CK_BYTE_PTR      pInitVector;
+  CK_UTF8CHAR_PTR  pPassword;
+  CK_ULONG         ulPasswordLen;
+  CK_BYTE_PTR      pSalt;
+  CK_ULONG         ulSaltLen;
+  CK_ULONG         ulIteration;
+} CK_PBE_PARAMS;
+
+typedef CK_PBE_PARAMS CK_PTR CK_PBE_PARAMS_PTR;
+
+
+/* CK_KEY_WRAP_SET_OAEP_PARAMS provides the parameters to the
+ * CKM_KEY_WRAP_SET_OAEP mechanism
+ */
+typedef struct CK_KEY_WRAP_SET_OAEP_PARAMS {
+  CK_BYTE       bBC;     /* block contents byte */
+  CK_BYTE_PTR   pX;      /* extra data */
+  CK_ULONG      ulXLen;  /* length of extra data in bytes */
+} CK_KEY_WRAP_SET_OAEP_PARAMS;
+
+typedef CK_KEY_WRAP_SET_OAEP_PARAMS CK_PTR CK_KEY_WRAP_SET_OAEP_PARAMS_PTR;
+
+typedef struct CK_SSL3_RANDOM_DATA {
+  CK_BYTE_PTR  pClientRandom;
+  CK_ULONG     ulClientRandomLen;
+  CK_BYTE_PTR  pServerRandom;
+  CK_ULONG     ulServerRandomLen;
+} CK_SSL3_RANDOM_DATA;
+
+
+typedef struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS {
+  CK_SSL3_RANDOM_DATA RandomInfo;
+  CK_VERSION_PTR pVersion;
+} CK_SSL3_MASTER_KEY_DERIVE_PARAMS;
+
+typedef struct CK_SSL3_MASTER_KEY_DERIVE_PARAMS CK_PTR \
+  CK_SSL3_MASTER_KEY_DERIVE_PARAMS_PTR;
+
+typedef struct CK_SSL3_KEY_MAT_OUT {
+  CK_OBJECT_HANDLE hClientMacSecret;
+  CK_OBJECT_HANDLE hServerMacSecret;
+  CK_OBJECT_HANDLE hClientKey;
+  CK_OBJECT_HANDLE hServerKey;
+  CK_BYTE_PTR      pIVClient;
+  CK_BYTE_PTR      pIVServer;
+} CK_SSL3_KEY_MAT_OUT;
+
+typedef CK_SSL3_KEY_MAT_OUT CK_PTR CK_SSL3_KEY_MAT_OUT_PTR;
+
+
+typedef struct CK_SSL3_KEY_MAT_PARAMS {
+  CK_ULONG                ulMacSizeInBits;
+  CK_ULONG                ulKeySizeInBits;
+  CK_ULONG                ulIVSizeInBits;
+  CK_BBOOL                bIsExport;
+  CK_SSL3_RANDOM_DATA     RandomInfo;
+  CK_SSL3_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
+} CK_SSL3_KEY_MAT_PARAMS;
+
+typedef CK_SSL3_KEY_MAT_PARAMS CK_PTR CK_SSL3_KEY_MAT_PARAMS_PTR;
+
+typedef struct CK_TLS_PRF_PARAMS {
+  CK_BYTE_PTR  pSeed;
+  CK_ULONG     ulSeedLen;
+  CK_BYTE_PTR  pLabel;
+  CK_ULONG     ulLabelLen;
+  CK_BYTE_PTR  pOutput;
+  CK_ULONG_PTR pulOutputLen;
+} CK_TLS_PRF_PARAMS;
+
+typedef CK_TLS_PRF_PARAMS CK_PTR CK_TLS_PRF_PARAMS_PTR;
+
+typedef struct CK_WTLS_RANDOM_DATA {
+  CK_BYTE_PTR pClientRandom;
+  CK_ULONG    ulClientRandomLen;
+  CK_BYTE_PTR pServerRandom;
+  CK_ULONG    ulServerRandomLen;
+} CK_WTLS_RANDOM_DATA;
+
+typedef CK_WTLS_RANDOM_DATA CK_PTR CK_WTLS_RANDOM_DATA_PTR;
+
+typedef struct CK_WTLS_MASTER_KEY_DERIVE_PARAMS {
+  CK_MECHANISM_TYPE   DigestMechanism;
+  CK_WTLS_RANDOM_DATA RandomInfo;
+  CK_BYTE_PTR         pVersion;
+} CK_WTLS_MASTER_KEY_DERIVE_PARAMS;
+
+typedef CK_WTLS_MASTER_KEY_DERIVE_PARAMS CK_PTR \
+  CK_WTLS_MASTER_KEY_DERIVE_PARAMS_PTR;
+
+typedef struct CK_WTLS_PRF_PARAMS {
+  CK_MECHANISM_TYPE DigestMechanism;
+  CK_BYTE_PTR       pSeed;
+  CK_ULONG          ulSeedLen;
+  CK_BYTE_PTR       pLabel;
+  CK_ULONG          ulLabelLen;
+  CK_BYTE_PTR       pOutput;
+  CK_ULONG_PTR      pulOutputLen;
+} CK_WTLS_PRF_PARAMS;
+
+typedef CK_WTLS_PRF_PARAMS CK_PTR CK_WTLS_PRF_PARAMS_PTR;
+
+typedef struct CK_WTLS_KEY_MAT_OUT {
+  CK_OBJECT_HANDLE hMacSecret;
+  CK_OBJECT_HANDLE hKey;
+  CK_BYTE_PTR      pIV;
+} CK_WTLS_KEY_MAT_OUT;
+
+typedef CK_WTLS_KEY_MAT_OUT CK_PTR CK_WTLS_KEY_MAT_OUT_PTR;
+
+typedef struct CK_WTLS_KEY_MAT_PARAMS {
+  CK_MECHANISM_TYPE       DigestMechanism;
+  CK_ULONG                ulMacSizeInBits;
+  CK_ULONG                ulKeySizeInBits;
+  CK_ULONG                ulIVSizeInBits;
+  CK_ULONG                ulSequenceNumber;
+  CK_BBOOL                bIsExport;
+  CK_WTLS_RANDOM_DATA     RandomInfo;
+  CK_WTLS_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
+} CK_WTLS_KEY_MAT_PARAMS;
+
+typedef CK_WTLS_KEY_MAT_PARAMS CK_PTR CK_WTLS_KEY_MAT_PARAMS_PTR;
+
+typedef struct CK_CMS_SIG_PARAMS {
+  CK_OBJECT_HANDLE      certificateHandle;
+  CK_MECHANISM_PTR      pSigningMechanism;
+  CK_MECHANISM_PTR      pDigestMechanism;
+  CK_UTF8CHAR_PTR       pContentType;
+  CK_BYTE_PTR           pRequestedAttributes;
+  CK_ULONG              ulRequestedAttributesLen;
+  CK_BYTE_PTR           pRequiredAttributes;
+  CK_ULONG              ulRequiredAttributesLen;
+} CK_CMS_SIG_PARAMS;
+
+typedef CK_CMS_SIG_PARAMS CK_PTR CK_CMS_SIG_PARAMS_PTR;
+
+typedef struct CK_KEY_DERIVATION_STRING_DATA {
+  CK_BYTE_PTR pData;
+  CK_ULONG    ulLen;
+} CK_KEY_DERIVATION_STRING_DATA;
+
+typedef CK_KEY_DERIVATION_STRING_DATA CK_PTR \
+  CK_KEY_DERIVATION_STRING_DATA_PTR;
+
+
+/* The CK_EXTRACT_PARAMS is used for the
+ * CKM_EXTRACT_KEY_FROM_KEY mechanism.  It specifies which bit
+ * of the base key should be used as the first bit of the
+ * derived key
+ */
+typedef CK_ULONG CK_EXTRACT_PARAMS;
+
+typedef CK_EXTRACT_PARAMS CK_PTR CK_EXTRACT_PARAMS_PTR;
+
+/* CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE is used to
+ * indicate the Pseudo-Random Function (PRF) used to generate
+ * key bits using PKCS #5 PBKDF2.
+ */
+typedef CK_ULONG CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE;
+
+typedef CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE CK_PTR \
+                        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE_PTR;
+
+#define CKP_PKCS5_PBKD2_HMAC_SHA1          0x00000001UL
+#define CKP_PKCS5_PBKD2_HMAC_GOSTR3411     0x00000002UL
+#define CKP_PKCS5_PBKD2_HMAC_SHA224        0x00000003UL
+#define CKP_PKCS5_PBKD2_HMAC_SHA256        0x00000004UL
+#define CKP_PKCS5_PBKD2_HMAC_SHA384        0x00000005UL
+#define CKP_PKCS5_PBKD2_HMAC_SHA512        0x00000006UL
+#define CKP_PKCS5_PBKD2_HMAC_SHA512_224    0x00000007UL
+#define CKP_PKCS5_PBKD2_HMAC_SHA512_256    0x00000008UL
+
+/* CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE is used to indicate the
+ * source of the salt value when deriving a key using PKCS #5
+ * PBKDF2.
+ */
+typedef CK_ULONG CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE;
+
+typedef CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE CK_PTR \
+                        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE_PTR;
+
+/* The following salt value sources are defined in PKCS #5 v2.0. */
+#define CKZ_SALT_SPECIFIED        0x00000001UL
+
+/* CK_PKCS5_PBKD2_PARAMS is a structure that provides the
+ * parameters to the CKM_PKCS5_PBKD2 mechanism.
+ */
+typedef struct CK_PKCS5_PBKD2_PARAMS {
+        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE           saltSource;
+        CK_VOID_PTR                                pSaltSourceData;
+        CK_ULONG                                   ulSaltSourceDataLen;
+        CK_ULONG                                   iterations;
+        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
+        CK_VOID_PTR                                pPrfData;
+        CK_ULONG                                   ulPrfDataLen;
+        CK_UTF8CHAR_PTR                            pPassword;
+        CK_ULONG_PTR                               ulPasswordLen;
+} CK_PKCS5_PBKD2_PARAMS;
+
+typedef CK_PKCS5_PBKD2_PARAMS CK_PTR CK_PKCS5_PBKD2_PARAMS_PTR;
+
+/* CK_PKCS5_PBKD2_PARAMS2 is a corrected version of the CK_PKCS5_PBKD2_PARAMS
+ * structure that provides the parameters to the CKM_PKCS5_PBKD2 mechanism
+ * noting that the ulPasswordLen field is a CK_ULONG and not a CK_ULONG_PTR.
+ */
+typedef struct CK_PKCS5_PBKD2_PARAMS2 {
+        CK_PKCS5_PBKDF2_SALT_SOURCE_TYPE saltSource;
+        CK_VOID_PTR pSaltSourceData;
+        CK_ULONG ulSaltSourceDataLen;
+        CK_ULONG iterations;
+        CK_PKCS5_PBKD2_PSEUDO_RANDOM_FUNCTION_TYPE prf;
+        CK_VOID_PTR pPrfData;
+        CK_ULONG ulPrfDataLen;
+        CK_UTF8CHAR_PTR pPassword;
+        CK_ULONG ulPasswordLen;
+} CK_PKCS5_PBKD2_PARAMS2;
+
+typedef CK_PKCS5_PBKD2_PARAMS2 CK_PTR CK_PKCS5_PBKD2_PARAMS2_PTR;
+
+typedef CK_ULONG CK_OTP_PARAM_TYPE;
+typedef CK_OTP_PARAM_TYPE CK_PARAM_TYPE; /* backward compatibility */
+
+typedef struct CK_OTP_PARAM {
+    CK_OTP_PARAM_TYPE type;
+    CK_VOID_PTR pValue;
+    CK_ULONG ulValueLen;
+} CK_OTP_PARAM;
+
+typedef CK_OTP_PARAM CK_PTR CK_OTP_PARAM_PTR;
+
+typedef struct CK_OTP_PARAMS {
+    CK_OTP_PARAM_PTR pParams;
+    CK_ULONG ulCount;
+} CK_OTP_PARAMS;
+
+typedef CK_OTP_PARAMS CK_PTR CK_OTP_PARAMS_PTR;
+
+typedef struct CK_OTP_SIGNATURE_INFO {
+    CK_OTP_PARAM_PTR pParams;
+    CK_ULONG ulCount;
+} CK_OTP_SIGNATURE_INFO;
+
+typedef CK_OTP_SIGNATURE_INFO CK_PTR CK_OTP_SIGNATURE_INFO_PTR;
+
+#define CK_OTP_VALUE          0UL
+#define CK_OTP_PIN            1UL
+#define CK_OTP_CHALLENGE      2UL
+#define CK_OTP_TIME           3UL
+#define CK_OTP_COUNTER        4UL
+#define CK_OTP_FLAGS          5UL
+#define CK_OTP_OUTPUT_LENGTH  6UL
+#define CK_OTP_OUTPUT_FORMAT  7UL
+
+#define CKF_NEXT_OTP          0x00000001UL
+#define CKF_EXCLUDE_TIME      0x00000002UL
+#define CKF_EXCLUDE_COUNTER   0x00000004UL
+#define CKF_EXCLUDE_CHALLENGE 0x00000008UL
+#define CKF_EXCLUDE_PIN       0x00000010UL
+#define CKF_USER_FRIENDLY_OTP 0x00000020UL
+
+typedef struct CK_KIP_PARAMS {
+    CK_MECHANISM_PTR  pMechanism;
+    CK_OBJECT_HANDLE  hKey;
+    CK_BYTE_PTR       pSeed;
+    CK_ULONG          ulSeedLen;
+} CK_KIP_PARAMS;
+
+typedef CK_KIP_PARAMS CK_PTR CK_KIP_PARAMS_PTR;
+
+typedef struct CK_AES_CTR_PARAMS {
+    CK_ULONG ulCounterBits;
+    CK_BYTE cb[16];
+} CK_AES_CTR_PARAMS;
+
+typedef CK_AES_CTR_PARAMS CK_PTR CK_AES_CTR_PARAMS_PTR;
+
+typedef struct CK_GCM_PARAMS {
+    CK_BYTE_PTR       pIv;
+    CK_ULONG          ulIvLen;
+    CK_ULONG          ulIvBits;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulTagBits;
+} CK_GCM_PARAMS;
+
+typedef CK_GCM_PARAMS CK_PTR CK_GCM_PARAMS_PTR;
+
+typedef struct CK_CCM_PARAMS {
+    CK_ULONG          ulDataLen;
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulMACLen;
+} CK_CCM_PARAMS;
+
+typedef CK_CCM_PARAMS CK_PTR CK_CCM_PARAMS_PTR;
+
+/* Deprecated. Use CK_GCM_PARAMS */
+typedef struct CK_AES_GCM_PARAMS {
+  CK_BYTE_PTR pIv;
+  CK_ULONG ulIvLen;
+  CK_ULONG ulIvBits;
+  CK_BYTE_PTR pAAD;
+  CK_ULONG ulAADLen;
+  CK_ULONG ulTagBits;
+} CK_AES_GCM_PARAMS;
+
+typedef CK_AES_GCM_PARAMS CK_PTR CK_AES_GCM_PARAMS_PTR;
+
+/* Deprecated. Use CK_CCM_PARAMS */
+typedef struct CK_AES_CCM_PARAMS {
+    CK_ULONG          ulDataLen;
+    CK_BYTE_PTR       pNonce;
+    CK_ULONG          ulNonceLen;
+    CK_BYTE_PTR       pAAD;
+    CK_ULONG          ulAADLen;
+    CK_ULONG          ulMACLen;
+} CK_AES_CCM_PARAMS;
+
+typedef CK_AES_CCM_PARAMS CK_PTR CK_AES_CCM_PARAMS_PTR;
+
+typedef struct CK_CAMELLIA_CTR_PARAMS {
+    CK_ULONG          ulCounterBits;
+    CK_BYTE           cb[16];
+} CK_CAMELLIA_CTR_PARAMS;
+
+typedef CK_CAMELLIA_CTR_PARAMS CK_PTR CK_CAMELLIA_CTR_PARAMS_PTR;
+
+typedef struct CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS {
+    CK_BYTE           iv[16];
+    CK_BYTE_PTR       pData;
+    CK_ULONG          length;
+} CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS;
+
+typedef CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
+                                CK_CAMELLIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+typedef struct CK_ARIA_CBC_ENCRYPT_DATA_PARAMS {
+    CK_BYTE           iv[16];
+    CK_BYTE_PTR       pData;
+    CK_ULONG          length;
+} CK_ARIA_CBC_ENCRYPT_DATA_PARAMS;
+
+typedef CK_ARIA_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
+                                CK_ARIA_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+typedef struct CK_DSA_PARAMETER_GEN_PARAM {
+    CK_MECHANISM_TYPE  hash;
+    CK_BYTE_PTR        pSeed;
+    CK_ULONG           ulSeedLen;
+    CK_ULONG           ulIndex;
+} CK_DSA_PARAMETER_GEN_PARAM;
+
+typedef CK_DSA_PARAMETER_GEN_PARAM CK_PTR CK_DSA_PARAMETER_GEN_PARAM_PTR;
+
+typedef struct CK_ECDH_AES_KEY_WRAP_PARAMS {
+    CK_ULONG           ulAESKeyBits;
+    CK_EC_KDF_TYPE     kdf;
+    CK_ULONG           ulSharedDataLen;
+    CK_BYTE_PTR        pSharedData;
+} CK_ECDH_AES_KEY_WRAP_PARAMS;
+
+typedef CK_ECDH_AES_KEY_WRAP_PARAMS CK_PTR CK_ECDH_AES_KEY_WRAP_PARAMS_PTR;
+
+typedef CK_ULONG CK_JAVA_MIDP_SECURITY_DOMAIN;
+
+typedef CK_ULONG CK_CERTIFICATE_CATEGORY;
+
+typedef struct CK_RSA_AES_KEY_WRAP_PARAMS {
+    CK_ULONG                      ulAESKeyBits;
+    CK_RSA_PKCS_OAEP_PARAMS_PTR   pOAEPParams;
+} CK_RSA_AES_KEY_WRAP_PARAMS;
+
+typedef CK_RSA_AES_KEY_WRAP_PARAMS CK_PTR CK_RSA_AES_KEY_WRAP_PARAMS_PTR;
+
+typedef struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
+    CK_SSL3_RANDOM_DATA       RandomInfo;
+    CK_VERSION_PTR            pVersion;
+    CK_MECHANISM_TYPE         prfHashMechanism;
+} CK_TLS12_MASTER_KEY_DERIVE_PARAMS;
+
+typedef CK_TLS12_MASTER_KEY_DERIVE_PARAMS CK_PTR \
+                                CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
+
+typedef struct CK_TLS12_KEY_MAT_PARAMS {
+    CK_ULONG                  ulMacSizeInBits;
+    CK_ULONG                  ulKeySizeInBits;
+    CK_ULONG                  ulIVSizeInBits;
+    CK_BBOOL                  bIsExport;
+    CK_SSL3_RANDOM_DATA       RandomInfo;
+    CK_SSL3_KEY_MAT_OUT_PTR   pReturnedKeyMaterial;
+    CK_MECHANISM_TYPE         prfHashMechanism;
+} CK_TLS12_KEY_MAT_PARAMS;
+
+typedef CK_TLS12_KEY_MAT_PARAMS CK_PTR CK_TLS12_KEY_MAT_PARAMS_PTR;
+
+typedef struct CK_TLS_KDF_PARAMS {
+    CK_MECHANISM_TYPE         prfMechanism;
+    CK_BYTE_PTR               pLabel;
+    CK_ULONG                  ulLabelLength;
+    CK_SSL3_RANDOM_DATA       RandomInfo;
+    CK_BYTE_PTR               pContextData;
+    CK_ULONG                  ulContextDataLength;
+} CK_TLS_KDF_PARAMS;
+
+typedef CK_TLS_KDF_PARAMS CK_PTR CK_TLS_KDF_PARAMS_PTR;
+
+typedef struct CK_TLS_MAC_PARAMS {
+    CK_MECHANISM_TYPE         prfHashMechanism;
+    CK_ULONG                  ulMacLength;
+    CK_ULONG                  ulServerOrClient;
+} CK_TLS_MAC_PARAMS;
+
+typedef CK_TLS_MAC_PARAMS CK_PTR CK_TLS_MAC_PARAMS_PTR;
+
+typedef struct CK_GOSTR3410_DERIVE_PARAMS {
+    CK_EC_KDF_TYPE            kdf;
+    CK_BYTE_PTR               pPublicData;
+    CK_ULONG                  ulPublicDataLen;
+    CK_BYTE_PTR               pUKM;
+    CK_ULONG                  ulUKMLen;
+} CK_GOSTR3410_DERIVE_PARAMS;
+
+typedef CK_GOSTR3410_DERIVE_PARAMS CK_PTR CK_GOSTR3410_DERIVE_PARAMS_PTR;
+
+typedef struct CK_GOSTR3410_KEY_WRAP_PARAMS {
+    CK_BYTE_PTR               pWrapOID;
+    CK_ULONG                  ulWrapOIDLen;
+    CK_BYTE_PTR               pUKM;
+    CK_ULONG                  ulUKMLen;
+    CK_OBJECT_HANDLE          hKey;
+} CK_GOSTR3410_KEY_WRAP_PARAMS;
+
+typedef CK_GOSTR3410_KEY_WRAP_PARAMS CK_PTR CK_GOSTR3410_KEY_WRAP_PARAMS_PTR;
+
+typedef struct CK_SEED_CBC_ENCRYPT_DATA_PARAMS {
+    CK_BYTE                   iv[16];
+    CK_BYTE_PTR               pData;
+    CK_ULONG                  length;
+} CK_SEED_CBC_ENCRYPT_DATA_PARAMS;
+
+typedef CK_SEED_CBC_ENCRYPT_DATA_PARAMS CK_PTR \
+                                        CK_SEED_CBC_ENCRYPT_DATA_PARAMS_PTR;
+
+#endif /* _PKCS11T_H_ */
+

--- a/src/client-c++/sf_pkcs11/meson.build
+++ b/src/client-c++/sf_pkcs11/meson.build
@@ -18,4 +18,5 @@ sf_pkcs11_lib = shared_library(
     'src/pkcs11-sf-statics.cpp',
     include_directories : 'include',
     dependencies: sf_pkcs11_deps,
+    install: get_option('lib-pkcs11')
 )

--- a/src/client-c++/sf_pkcs11/meson.build
+++ b/src/client-c++/sf_pkcs11/meson.build
@@ -1,0 +1,21 @@
+cc = meson.get_compiler('cpp')
+
+sf_pkcs11_deps = [
+    dependency('json-c'),
+    dependency('libcrypto'),
+    sf_client_dep
+]
+
+sf_pkcs11_lib = shared_library(
+    'sf_pkcs11',
+    'src/pkcs11-sf-client.cpp',
+    'src/pkcs11-sf-json.cpp',
+    'src/pkcs11-sf-module.cpp',
+    'src/pkcs11-sf-object.cpp',
+    'src/pkcs11-sf-session.cpp',
+    'src/pkcs11-sf-slot.cpp',
+    'src/pkcs11-sf-token.cpp',
+    'src/pkcs11-sf-statics.cpp',
+    include_directories : 'include',
+    dependencies: sf_pkcs11_deps,
+)

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-client.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-client.cpp
@@ -1,0 +1,1720 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <csignal>
+#include <curl/curl.h>
+#include <fstream>
+#include <iostream>
+#include <json-c/json.h>
+#include <openssl/engine.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <sf_client/sf_client.h>
+#include <sf_utils/sf_utils.h>
+#include <string.h>
+#include <string>
+#include <termios.h>
+#include <vector>
+
+#include "pkcs11-sf-json.h"
+#include "pkcs11-sf-module.h"
+#include "pkcs11-sf-types.h"
+
+#include "pkcs11-sf-client.h"
+
+#ifdef DEBUG
+#undef DEBUG
+#define DEBUG(string) std::cout << string << std::endl;
+#else
+#define DEBUG(string)
+#endif
+
+PKCS11_SfModule* SfModule = NULL;
+
+// API defined at:
+// http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/pkcs11-base-v2.40.html
+
+CK_FUNCTION_LIST PKCS11_SF_Client_Functions = {{CryptokiVersionMajor, CryptokiVersionMinor},
+                                               &C_Initialize,
+                                               &C_Finalize,
+                                               &C_GetInfo,
+                                               &C_GetFunctionList,
+                                               &C_GetSlotList,
+                                               &C_GetSlotInfo,
+                                               &C_GetTokenInfo,
+                                               &C_GetMechanismList,
+                                               &C_GetMechanismInfo,
+                                               &C_InitToken,
+                                               &C_InitPIN,
+                                               &C_SetPIN,
+                                               &C_OpenSession,
+                                               &C_CloseSession,
+                                               &C_CloseAllSessions,
+                                               &C_GetSessionInfo,
+                                               &C_GetOperationState,
+                                               &C_SetOperationState,
+                                               &C_Login,
+                                               &C_Logout,
+                                               &C_CreateObject,
+                                               &C_CopyObject,
+                                               &C_DestroyObject,
+                                               &C_GetObjectSize,
+                                               &C_GetAttributeValue,
+                                               &C_SetAttributeValue,
+                                               &C_FindObjectsInit,
+                                               &C_FindObjects,
+                                               &C_FindObjectsFinal,
+                                               &C_EncryptInit,
+                                               &C_Encrypt,
+                                               &C_EncryptUpdate,
+                                               &C_EncryptFinal,
+                                               &C_DecryptInit,
+                                               &C_Decrypt,
+                                               &C_DecryptUpdate,
+                                               &C_DecryptFinal,
+                                               &C_DigestInit,
+                                               &C_Digest,
+                                               &C_DigestUpdate,
+                                               &C_DigestKey,
+                                               &C_DigestFinal,
+                                               &C_SignInit,
+                                               &C_Sign,
+                                               &C_SignUpdate,
+                                               &C_SignFinal,
+                                               &C_SignRecoverInit,
+                                               &C_SignRecover,
+                                               &C_VerifyInit,
+                                               &C_Verify,
+                                               &C_VerifyUpdate,
+                                               &C_VerifyFinal,
+                                               &C_VerifyRecoverInit,
+                                               &C_VerifyRecover,
+                                               &C_DigestEncryptUpdate,
+                                               &C_DecryptDigestUpdate,
+                                               &C_SignEncryptUpdate,
+                                               &C_DecryptVerifyUpdate,
+                                               &C_GenerateKey,
+                                               &C_GenerateKeyPair,
+                                               &C_WrapKey,
+                                               &C_UnwrapKey,
+                                               &C_DeriveKey,
+                                               &C_SeedRandom,
+                                               &C_GenerateRandom,
+                                               &C_GetFunctionStatus,
+                                               &C_CancelFunction,
+                                               &C_WaitForSlotEvent};
+
+// C_Initialize initializes the Cryptoki library.  pInitArgs either has the value NULL_PTR or points
+// to a CK_C_INITIALIZE_ARGS structure containing information on how the library should deal with
+// multi-threaded access.
+// Return values: CKR_ARGUMENTS_BAD, CKR_CANT_LOCK,
+// CKR_CRYPTOKI_ALREADY_INITIALIZED, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+// CKR_NEED_TO_CREATE_THREADS, CKR_OK.
+CK_DECLARE_FUNCTION(CK_RV, C_Initialize)(CK_VOID_PTR pInitArgs)
+{
+    DEBUG("CINIT START");
+    if(pInitArgs)
+    {
+        DEBUG("CINIT START-1");
+        // Received data about locking
+        // Contains:
+        // CreateMutex, DestroyMutex, LockMutex, UnlockMutex, flags, and pReserved
+        CK_C_INITIALIZE_ARGS_PTR sArgsPtr = (CK_C_INITIALIZE_ARGS_PTR)(pInitArgs);
+
+        // pReserved is required to be NULL, if not the spec requires CKR_ARG_BAD to be returned
+        if(NULL_PTR != sArgsPtr->pReserved)
+        {
+            DEBUG("CINIT START-2");
+            return CKR_ARGUMENTS_BAD;
+        }
+
+        // For simplicity, this library will not support multiple threads. So it doens't care about
+        // most of these parms.
+
+        // Application supports native OS locking/thread mechanisms
+        if(CKF_OS_LOCKING_OK & sArgsPtr->flags)
+        {
+            DEBUG("CINIT START-3");
+            // Multithreading not supported
+            // return CKR_CANT_LOCK;
+        }
+        else
+        {
+            // Application is doing multi-threading work and the library must use these functions
+            // for mutex-handling
+            if(NULL_PTR != sArgsPtr->CreateMutex && NULL_PTR != sArgsPtr->DestroyMutex
+               && NULL_PTR != sArgsPtr->LockMutex && NULL_PTR != sArgsPtr->UnlockMutex)
+            {
+                DEBUG("CINIT START-4");
+                return CKR_CANT_LOCK;
+            }
+            else if(NULL_PTR != sArgsPtr->CreateMutex || NULL_PTR != sArgsPtr->DestroyMutex
+                    || NULL_PTR != sArgsPtr->LockMutex || NULL_PTR != sArgsPtr->UnlockMutex)
+            {
+                DEBUG("CINIT START-5");
+                // Either all pointers should be valid or none should be valid. Return an error
+                // since only some are valid.
+                return CKR_ARGUMENTS_BAD;
+            }
+            else
+            {
+                DEBUG("CINIT START-6");
+                // Application is not accessing library from multiple threads. Equivalent to
+                // pInitArgs being set to NULL_PTR.
+            }
+        }
+    }
+    else
+    {
+        // Did not receive data about locking. Application is not accessing library from multiple
+        // threads. No additional checking required.
+    }
+    DEBUG("CINIT START-7");
+
+    PKCS11_SF_SESSION_CONFIG sConfig;
+    // TODO: pull from environment variable
+
+    const char* sJsonPath = getenv("SF_PKCS11_CONFIG");
+    if(!sJsonPath)
+    {
+        std::cout << "SF_PKCS11_CONFIG environment variable not defined" << std::endl;
+        return CKR_GENERAL_ERROR;
+    }
+
+    bool sJsonSuccess = ParseJsonConfig(sJsonPath, sConfig);
+    if(!sJsonSuccess)
+        return CKR_GENERAL_ERROR;
+    std::cout << sJsonSuccess << std::endl;
+
+    SfModule = new PKCS11_SfModule();
+    if(!SfModule)
+    {
+        return CKR_HOST_MEMORY;
+    }
+
+    // DEBUG("ATTEMPT GET PASSWORD:");
+    // bool sPasswordSuccess = SfModule->promptPassword();
+    // if(!sPasswordSuccess)
+    //{
+    //    std::cout << "Error setting password" << std::endl;
+    //    return CKR_GENERAL_ERROR;
+    //}
+
+    DEBUG("ATTEMPT OPEN CONNECTION:");
+    bool sCurlSuccess = SfModule->openServerConnection(
+        sConfig.mUrl, sConfig.mEpwdPath, sConfig.mPrivateKeyPath);
+    if(!sCurlSuccess)
+    {
+        std::cout << "Error opening connection" << std::endl;
+        return CKR_GENERAL_ERROR;
+    }
+
+    DEBUG("ATTEMPT INIT OBJECTS:");
+    bool sInitSuccess = SfModule->initObjects(sConfig);
+    if(!sInitSuccess)
+    {
+        std::cout << "Error init'ing objects" << std::endl;
+        return CKR_GENERAL_ERROR;
+    }
+
+    DEBUG("INIT END");
+
+    return CKR_OK;
+}
+
+/* C_Finalize indicates that an application is done with the
+ * Cryptoki library.
+ */
+// Return values: CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED, CKR_FUNCTION_FAILED,
+// CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK.
+CK_DECLARE_FUNCTION(CK_RV, C_Finalize)(CK_VOID_PTR pReserved)
+{
+    DEBUG("C_FINALIZE START");
+    (void)pReserved;
+    if(SfModule)
+    {
+        SfModule->closeServerConnection();
+        delete SfModule;
+        SfModule = NULL;
+    }
+    return CKR_OK;
+}
+
+/* C_GetInfo returns general information about Cryptoki. */
+// Return values: CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED, CKR_FUNCTION_FAILED,
+// CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK.
+CK_DECLARE_FUNCTION(CK_RV, C_GetInfo)(CK_INFO_PTR pInfo)
+{
+    DEBUG("C_GETINFO START")
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+    if(NULL_PTR == pInfo)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    // pkcs11t.h:
+    // typedef struct CK_INFO {
+    //   CK_VERSION    cryptokiVersion;     /* Cryptoki interface ver */
+    //   CK_UTF8CHAR   manufacturerID[32];  /* blank padded */
+    //   CK_FLAGS      flags;               /* must be zero */
+    //   CK_UTF8CHAR   libraryDescription[32];  /* blank padded */
+    //   CK_VERSION    libraryVersion;          /* version of library */
+    // } CK_INFO;
+
+    pInfo->cryptokiVersion = SfModule->getCryptokiVersion();
+    SfModule->getManufacturerId(pInfo->manufacturerID, sizeof(pInfo->manufacturerID));
+    pInfo->flags = SfModule->getFlags();
+    SfModule->getDescription(pInfo->libraryDescription, sizeof(pInfo->libraryDescription));
+    pInfo->libraryVersion = SfModule->getLibraryVersion();
+
+    return CKR_OK;
+}
+
+/* C_GetFunctionList returns the function list. */
+// Return values: CKR_ARGUMENTS_BAD, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY,
+// CKR_OK.
+CK_DECLARE_FUNCTION(CK_RV, C_GetFunctionList)
+(CK_FUNCTION_LIST_PTR_PTR ppFunctionList /* receives pointer to function list */)
+{
+    DEBUG("C_GETFUNCTIONLIST START")
+    if(!ppFunctionList)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    *ppFunctionList = &PKCS11_SF_Client_Functions;
+    DEBUG("C_GETFUNCTIONLIST FINISH")
+    return CKR_OK;
+}
+
+/* Slot and token management */
+
+/* C_GetSlotList obtains a list of slots in the system. */
+// Return values: CKR_ARGUMENTS_BAD, CKR_BUFFER_TOO_SMALL, CKR_CRYPTOKI_NOT_INITIALIZED,
+// CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK.
+CK_DECLARE_FUNCTION(CK_RV, C_GetSlotList)
+(CK_BBOOL       tokenPresent, /* only slots with tokens */
+ CK_SLOT_ID_PTR pSlotList,    /* receives array of slot IDs */
+ CK_ULONG_PTR   pulCount      /* receives number of slots */
+)
+{
+    DEBUG("C_GetSlotList START");
+    if(!SfModule)
+
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    if(NULL_PTR == pulCount)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    if(NULL_PTR == pSlotList)
+    {
+        // Application is requesting the number of slots in the library
+        *pulCount = SfModule->mNumberOfSlots;
+    }
+    else
+    {
+        if(*pulCount < SfModule->mNumberOfSlots)
+        {
+            return CKR_BUFFER_TOO_SMALL;
+        }
+
+        // Slots are always populated with a token, so tokenPresent will not change the output
+        (void)tokenPresent;
+
+        // Hardcoded to only have one slot
+        pSlotList[0] = 0; // Hardcode to slot index 0
+        *pulCount    = 1;
+    }
+    DEBUG("C_GetSlotList FINISH");
+    return CKR_OK;
+}
+
+/* C_GetSlotInfo obtains information about a particular slot in
+ * the system.
+ */
+// Return values: CKR_ARGUMENTS_BAD, CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
+// CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK, CKR_SLOT_ID_INVALID.
+CK_DECLARE_FUNCTION(CK_RV, C_GetSlotInfo)
+(CK_SLOT_ID       slotID, /* the ID of the slot */
+ CK_SLOT_INFO_PTR pInfo   /* receives the slot information */
+)
+{
+    DEBUG("C_GetSlotInfo START");
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+    if(NULL_PTR == pInfo)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(slotID);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    // pkcs11t.h:
+    // typedef struct CK_SLOT_INFO {
+    //  CK_UTF8CHAR   slotDescription[64];  /* blank padded */
+    //  CK_UTF8CHAR   manufacturerID[32];   /* blank padded */
+    //  CK_FLAGS      flags;
+    //
+    //  CK_VERSION    hardwareVersion;  /* version of hardware */
+    //  CK_VERSION    firmwareVersion;  /* version of firmware */
+    //} CK_SLOT_INFO;
+
+    sSlotPtr->getDescription(pInfo->slotDescription, sizeof(pInfo->slotDescription));
+    sSlotPtr->getManufacturerId(pInfo->manufacturerID, sizeof(pInfo->manufacturerID));
+    pInfo->flags           = sSlotPtr->getFlags();
+    pInfo->hardwareVersion = sSlotPtr->getHardwareVersion();
+    pInfo->firmwareVersion = sSlotPtr->getFirmwareVersion();
+
+    return CKR_OK;
+}
+
+/* C_GetTokenInfo obtains information about a particular token
+ * in the system.
+ */
+// Return values: CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY,
+// CKR_DEVICE_REMOVED, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+// CKR_SLOT_ID_INVALID, CKR_TOKEN_NOT_PRESENT, CKR_TOKEN_NOT_RECOGNIZED, CKR_ARGUMENTS_BAD.
+CK_DECLARE_FUNCTION(CK_RV, C_GetTokenInfo)
+
+(CK_SLOT_ID        slotID, /* ID of the token's slot */
+ CK_TOKEN_INFO_PTR pInfo   /* receives the token information */
+)
+{
+    DEBUG("C_GetTokenInfo START");
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+    if(NULL_PTR == pInfo)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(slotID);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken& sToken = sSlotPtr->getToken();
+
+    bool sIsSuccess = sToken.getTokenInfo(pInfo);
+    if(!sIsSuccess)
+    {
+        return CKR_GENERAL_ERROR;
+    }
+    return CKR_OK;
+}
+
+/* C_GetMechanismList obtains a list of mechanism types
+ * supported by a token.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GetMechanismList)
+
+(CK_SLOT_ID            slotID,         /* ID of token's slot */
+ CK_MECHANISM_TYPE_PTR pMechanismList, /* gets mech. array */
+ CK_ULONG_PTR          pulCount        /* gets # of mechs. */
+)
+{
+    (void)slotID;
+    DEBUG("C_GetMechanismList");
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+    if(NULL_PTR == pulCount)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    // TODO
+    if(NULL_PTR == pMechanismList)
+    {
+        *pulCount = 1;
+    }
+    else
+    {
+        if(1 > *pulCount)
+            return CKR_BUFFER_TOO_SMALL;
+
+        pMechanismList[0] = CKM_SHA512_RSA_PKCS;
+    }
+
+    return CKR_OK;
+}
+
+/* C_GetMechanismInfo obtains information about a particular
+ * mechanism possibly supported by a token.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GetMechanismInfo)
+
+(CK_SLOT_ID            slotID, /* ID of the token's slot */
+ CK_MECHANISM_TYPE     type,   /* type of mechanism */
+ CK_MECHANISM_INFO_PTR pInfo   /* receives mechanism info */
+)
+{
+    DEBUG("C_GetMechanismInfo");
+    (void)slotID;
+    (void)type;
+    (void)pInfo;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_InitToken initializes a token. */
+CK_DECLARE_FUNCTION(CK_RV, C_InitToken)
+
+(CK_SLOT_ID      slotID,   /* ID of the token's slot */
+ CK_UTF8CHAR_PTR pPin,     /* the SO's initial PIN */
+ CK_ULONG        ulPinLen, /* length in bytes of the PIN */
+ CK_UTF8CHAR_PTR pLabel    /* 32-byte token label (blank padded) */
+)
+{
+    DEBUG("C_InitToken");
+    (void)slotID;
+    (void)pPin;
+    (void)ulPinLen;
+    (void)pLabel;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_InitPIN initializes the normal user's PIN. */
+CK_DECLARE_FUNCTION(CK_RV, C_InitPIN)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_UTF8CHAR_PTR   pPin,     /* the normal user's PIN */
+ CK_ULONG          ulPinLen  /* length in bytes of the PIN */
+)
+{
+    DEBUG("C_InitPIN");
+    (void)hSession;
+    (void)pPin;
+    (void)ulPinLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_SetPIN modifies the PIN of the user who is logged in. */
+CK_DECLARE_FUNCTION(CK_RV, C_SetPIN)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_UTF8CHAR_PTR   pOldPin,  /* the old PIN */
+ CK_ULONG          ulOldLen, /* length of the old PIN */
+ CK_UTF8CHAR_PTR   pNewPin,  /* the new PIN */
+ CK_ULONG          ulNewLen  /* length of the new PIN */
+)
+{
+    DEBUG("C_SetPIN");
+    (void)hSession;
+    (void)pOldPin;
+    (void)ulOldLen;
+    (void)pNewPin;
+    (void)ulNewLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Session management */
+
+/* C_OpenSession opens a session between an application and a
+ * token.
+ */
+// Return values: CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY,
+// CKR_DEVICE_REMOVED, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+// CKR_SESSION_COUNT, CKR_SESSION_PARALLEL_NOT_SUPPORTED, CKR_SESSION_READ_WRITE_SO_EXISTS,
+// CKR_SLOT_ID_INVALID, CKR_TOKEN_NOT_PRESENT, CKR_TOKEN_NOT_RECOGNIZED, CKR_TOKEN_WRITE_PROTECTED,
+// CKR_ARGUMENTS_BAD.
+bool sessionexists = false;
+CK_DECLARE_FUNCTION(CK_RV, C_OpenSession)
+
+(CK_SLOT_ID            slotID,       /* the slot's ID */
+ CK_FLAGS              flags,        /* from CK_SESSION_INFO */
+ CK_VOID_PTR           pApplication, /* passed to callback */
+ CK_NOTIFY             Notify,       /* callback function */
+ CK_SESSION_HANDLE_PTR phSession     /* gets session handle */
+)
+{
+    DEBUG("C_OpenSession " << std::hex << flags << std::dec << " " << slotID);
+
+    (void)flags;
+    (void)pApplication;
+    (void)Notify;
+
+    // Sessions are opened on tokens. For sf_client, there is one token per slot, we can reuse the
+    // slotID as the session handle.
+
+    // Deviation from PKCS11: Authentication with user input is for setting up the initial sftp
+    // connection. This needs to be established BEFORE PKCS11 would call C_Login since the public
+    // key parameters need to be pulled from the signing server to populate the modulus and public
+    // exponent of the private key (openssl checks for these).
+    // Thus we must authenticate on the session opening, not when we log into the adapter.
+
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(slotID);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    if(sessionexists)
+    {
+        *phSession = slotID;
+        return CKR_OK;
+    }
+
+    bool sIsSuccess = true;
+
+    if(!sIsSuccess)
+    {
+        return CKR_GENERAL_ERROR;
+    }
+
+    PKCS11_SfToken& sToken = sSlotPtr->getToken();
+
+    sIsSuccess = sToken.requestSession();
+    if(!sIsSuccess)
+    {
+        return CKR_SESSION_COUNT;
+    }
+
+    *phSession    = slotID;
+    sessionexists = true;
+
+    return CKR_OK;
+}
+
+/* C_CloseSession closes a session between an application and a
+ * token.
+ */
+// Return values: CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY,
+// CKR_DEVICE_REMOVED, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK,
+// CKR_SESSION_CLOSED, CKR_SESSION_HANDLE_INVALID.
+CK_DECLARE_FUNCTION(CK_RV, C_CloseSession)
+
+(CK_SESSION_HANDLE hSession /* the session's handle */
+)
+{
+    DEBUG("C_CloseSession");
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    // Session ID == Slot Number
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken& sToken = sSlotPtr->getToken();
+
+    // PKCS11_SfSession& sSession = sToken.getSession();
+
+    // sSession.closeConnection();
+    sToken.releaseSession();
+    sessionexists = false;
+
+    return CKR_OK;
+}
+
+/* C_CloseAllSessions closes all sessions with a token. */
+CK_DECLARE_FUNCTION(CK_RV, C_CloseAllSessions)
+
+(CK_SLOT_ID slotID /* the token's slot */
+)
+{
+    DEBUG("C_CloseAllSessions");
+    (void)slotID;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_GetSessionInfo obtains information about the session. */
+CK_DECLARE_FUNCTION(CK_RV, C_GetSessionInfo)
+
+(CK_SESSION_HANDLE   hSession, /* the session's handle */
+ CK_SESSION_INFO_PTR pInfo     /* receives session info */
+)
+{
+    DEBUG("C_GetSessionInfo");
+    (void)hSession;
+    (void)pInfo;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_GetOperationState obtains the state of the cryptographic operation
+ * in a session.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GetOperationState)
+
+(CK_SESSION_HANDLE hSession,            /* session's handle */
+ CK_BYTE_PTR       pOperationState,     /* gets state */
+ CK_ULONG_PTR      pulOperationStateLen /* gets state length */
+)
+{
+    DEBUG("C_GetOperationState");
+    (void)hSession;
+    (void)pOperationState;
+    (void)pulOperationStateLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_SetOperationState restores the state of the cryptographic
+ * operation in a session.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SetOperationState)
+
+(CK_SESSION_HANDLE hSession,            /* session's handle */
+ CK_BYTE_PTR       pOperationState,     /* holds state */
+ CK_ULONG          ulOperationStateLen, /* holds state length */
+ CK_OBJECT_HANDLE  hEncryptionKey,      /* en/decryption key */
+ CK_OBJECT_HANDLE  hAuthenticationKey   /* sign/verify key */
+)
+{
+    DEBUG("C_SetOperationState");
+    (void)hSession;
+    (void)pOperationState;
+    (void)ulOperationStateLen;
+    (void)hEncryptionKey;
+    (void)hAuthenticationKey;
+
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_Login logs a user into a token. */
+CK_DECLARE_FUNCTION(CK_RV, C_Login)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_USER_TYPE      userType, /* the user type */
+ CK_UTF8CHAR_PTR   pPin,     /* the user's PIN */
+ CK_ULONG          ulPinLen  /* the length of the PIN */
+)
+{
+    DEBUG("C_Login");
+    (void)hSession;
+    (void)userType;
+    (void)pPin;
+    (void)ulPinLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_Logout logs a user out from a token. */
+CK_DECLARE_FUNCTION(CK_RV, C_Logout)
+
+(CK_SESSION_HANDLE hSession /* the session's handle */
+)
+{
+    DEBUG("C_Logout");
+    (void)hSession;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Object management */
+
+/* C_CreateObject creates a new object. */
+CK_DECLARE_FUNCTION(CK_RV, C_CreateObject)
+
+(CK_SESSION_HANDLE    hSession,  /* the session's handle */
+ CK_ATTRIBUTE_PTR     pTemplate, /* the object's template */
+ CK_ULONG             ulCount,   /* attributes in template */
+ CK_OBJECT_HANDLE_PTR phObject   /* gets new object's handle. */
+)
+{
+    DEBUG("C_CreateObject");
+    (void)hSession;
+    (void)pTemplate;
+    (void)ulCount;
+    (void)phObject;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_CopyObject copies an object, creating a new object for the
+ * copy.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_CopyObject)
+
+(CK_SESSION_HANDLE    hSession,   /* the session's handle */
+ CK_OBJECT_HANDLE     hObject,    /* the object's handle */
+ CK_ATTRIBUTE_PTR     pTemplate,  /* template for new object */
+ CK_ULONG             ulCount,    /* attributes in template */
+ CK_OBJECT_HANDLE_PTR phNewObject /* receives handle of copy */
+)
+{
+    DEBUG("C_CopyObject");
+    (void)hSession;
+    (void)hObject;
+    (void)pTemplate;
+    (void)ulCount;
+    (void)phNewObject;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DestroyObject destroys an object. */
+CK_DECLARE_FUNCTION(CK_RV, C_DestroyObject)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_OBJECT_HANDLE  hObject   /* the object's handle */
+)
+{
+    DEBUG("C_Destroy");
+    (void)hSession;
+    (void)hObject;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_GetObjectSize gets the size of an object in bytes. */
+CK_DECLARE_FUNCTION(CK_RV, C_GetObjectSize)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_OBJECT_HANDLE  hObject,  /* the object's handle */
+ CK_ULONG_PTR      pulSize   /* receives size of object */
+)
+{
+    DEBUG("C_GetObjectSize");
+    (void)hSession;
+    (void)hObject;
+    (void)pulSize;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_GetAttributeValue obtains the value of one or more object
+ * attributes.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GetAttributeValue)
+
+(CK_SESSION_HANDLE hSession,  /* the session's handle */
+ CK_OBJECT_HANDLE  hObject,   /* the object's handle */
+ CK_ATTRIBUTE_PTR  pTemplate, /* specifies attrs{} gets vals */
+ CK_ULONG          ulCount    /* attributes in template */
+)
+{
+    DEBUG("C_GetAttributeValue");
+
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    // Session ID == Slot Number
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken& sToken = sSlotPtr->getToken();
+
+    PKCS11_SfSession& sSession = sToken.getSession();
+
+    // TODO: handle null ptr
+    const SfKey* sKeyPtr = sSession.getKey(hObject);
+    if(!sKeyPtr)
+    {
+        DEBUG("BAD ARGUMENT: hObject " << std::dec << hObject);
+        exit(0);
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    for(CK_ULONG sIdx = 0; sIdx < ulCount; sIdx++)
+    {
+        CK_ATTRIBUTE& sTemplate = pTemplate[sIdx];
+
+        DEBUG("\tC_GetAttributeValue: " << std::hex << sTemplate.type);
+
+        sKeyPtr->getAttribute(sTemplate.type, sTemplate.pValue, sTemplate.ulValueLen);
+    }
+
+    return CKR_OK;
+}
+
+/* C_SetAttributeValue modifies the value of one or more object
+ * attributes.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SetAttributeValue)
+
+(CK_SESSION_HANDLE hSession,  /* the session's handle */
+ CK_OBJECT_HANDLE  hObject,   /* the object's handle */
+ CK_ATTRIBUTE_PTR  pTemplate, /* specifies attrs and values */
+ CK_ULONG          ulCount    /* attributes in template */
+)
+{
+    DEBUG("C_SetAttributeValue");
+    (void)hSession;
+    (void)hObject;
+    (void)pTemplate;
+    (void)ulCount;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_FindObjectsInit initializes a search for token and session
+ * objects that match a template.
+ */
+// Return values: CKR_ARGUMENTS_BAD, CKR_ATTRIBUTE_TYPE_INVALID, CKR_ATTRIBUTE_VALUE_INVALID,
+// CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR, CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED,
+// CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR, CKR_HOST_MEMORY, CKR_OK, CKR_OPERATION_ACTIVE,
+// CKR_PIN_EXPIRED, CKR_SESSION_CLOSED, CKR_SESSION_HANDLE_INVALID.
+CK_DECLARE_FUNCTION(CK_RV, C_FindObjectsInit)
+
+(CK_SESSION_HANDLE hSession,  /* the session's handle */
+ CK_ATTRIBUTE_PTR  pTemplate, /* attribute values to match */
+ CK_ULONG          ulCount    /* attrs in search template */
+)
+{
+    DEBUG("C_FindObjectsInit START");
+
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken&   sToken   = sSlotPtr->getToken();
+    PKCS11_SfSession& sSession = sToken.getSession();
+
+    sSession.initSearch(pTemplate, ulCount);
+
+    return CKR_OK;
+}
+
+/* C_FindObjects continues a search for token and session
+ * objects that match a template, obtaining additional object
+ * handles.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_FindObjects)
+
+(CK_SESSION_HANDLE    hSession,         /* session's handle */
+ CK_OBJECT_HANDLE_PTR phObject,         /* gets obj. handles */
+ CK_ULONG             ulMaxObjectCount, /* max handles to get */
+ CK_ULONG_PTR         pulObjectCount    /* actual # returned */
+)
+{
+    DEBUG("C_FindObjects START");
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken&   sToken   = sSlotPtr->getToken();
+    PKCS11_SfSession& sSession = sToken.getSession();
+
+    sSession.doSearch(phObject, ulMaxObjectCount, *pulObjectCount);
+
+    return CKR_OK;
+}
+
+/* C_FindObjectsFinal finishes a search for token and session
+ * objects.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_FindObjectsFinal)
+
+(CK_SESSION_HANDLE hSession /* the session's handle */
+)
+{
+    DEBUG("C_FindObjectsFinal");
+
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken&   sToken   = sSlotPtr->getToken();
+    PKCS11_SfSession& sSession = sToken.getSession();
+
+    sSession.endSearch();
+    return CKR_OK;
+}
+
+/* Encryption and decryption */
+
+/* C_EncryptInit initializes an encryption operation. */
+CK_DECLARE_FUNCTION(CK_RV, C_EncryptInit)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism, /* the encryption mechanism */
+ CK_OBJECT_HANDLE  hKey        /* handle of encryption key */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_Encrypt encrypts single-part data. */
+CK_DECLARE_FUNCTION(CK_RV, C_Encrypt)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pData,              /* the plaintext data */
+ CK_ULONG          ulDataLen,          /* bytes of plaintext */
+ CK_BYTE_PTR       pEncryptedData,     /* gets ciphertext */
+ CK_ULONG_PTR      pulEncryptedDataLen /* gets c-text size */
+)
+{
+    (void)hSession;
+    (void)pData;
+    (void)ulDataLen;
+    (void)pEncryptedData;
+    (void)pulEncryptedDataLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_EncryptUpdate continues a multiple-part encryption
+ * operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_EncryptUpdate)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pPart,              /* the plaintext data */
+ CK_ULONG          ulPartLen,          /* plaintext data len */
+ CK_BYTE_PTR       pEncryptedPart,     /* gets ciphertext */
+ CK_ULONG_PTR      pulEncryptedPartLen /* gets c-text size */
+)
+{
+    (void)hSession;
+    (void)pPart;
+    (void)ulPartLen;
+    (void)pEncryptedPart;
+    (void)pulEncryptedPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_EncryptFinal finishes a multiple-part encryption
+ * operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_EncryptFinal)
+
+(CK_SESSION_HANDLE hSession,               /* session handle */
+ CK_BYTE_PTR       pLastEncryptedPart,     /* last c-text */
+ CK_ULONG_PTR      pulLastEncryptedPartLen /* gets last size */
+)
+{
+    (void)hSession;
+    (void)pLastEncryptedPart;
+    (void)pulLastEncryptedPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DecryptInit initializes a decryption operation. */
+CK_DECLARE_FUNCTION(CK_RV, C_DecryptInit)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism, /* the decryption mechanism */
+ CK_OBJECT_HANDLE  hKey        /* handle of decryption key */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_Decrypt decrypts encrypted data in a single part. */
+CK_DECLARE_FUNCTION(CK_RV, C_Decrypt)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pEncryptedData,     /* ciphertext */
+ CK_ULONG          ulEncryptedDataLen, /* ciphertext length */
+ CK_BYTE_PTR       pData,              /* gets plaintext */
+ CK_ULONG_PTR      pulDataLen          /* gets p-text size */
+)
+{
+    (void)hSession;
+    (void)pEncryptedData;
+    (void)ulEncryptedDataLen;
+    (void)pData;
+    (void)pulDataLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DecryptUpdate continues a multiple-part decryption
+ * operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DecryptUpdate)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pEncryptedPart,     /* encrypted data */
+ CK_ULONG          ulEncryptedPartLen, /* input length */
+ CK_BYTE_PTR       pPart,              /* gets plaintext */
+ CK_ULONG_PTR      pulPartLen          /* p-text size */
+)
+{
+    (void)hSession;
+    (void)pEncryptedPart;
+    (void)ulEncryptedPartLen;
+    (void)pPart;
+    (void)pulPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DecryptFinal finishes a multiple-part decryption
+ * operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DecryptFinal)
+
+(CK_SESSION_HANDLE hSession,      /* the session's handle */
+ CK_BYTE_PTR       pLastPart,     /* gets plaintext */
+ CK_ULONG_PTR      pulLastPartLen /* p-text size */
+)
+{
+    (void)hSession;
+    (void)pLastPart;
+    (void)pulLastPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Message digesting */
+
+/* C_DigestInit initializes a message-digesting operation. */
+CK_DECLARE_FUNCTION(CK_RV, C_DigestInit)
+
+(CK_SESSION_HANDLE hSession,  /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism /* the digesting mechanism */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_Digest digests data in a single part. */
+CK_DECLARE_FUNCTION(CK_RV, C_Digest)
+
+(CK_SESSION_HANDLE hSession,    /* the session's handle */
+ CK_BYTE_PTR       pData,       /* data to be digested */
+ CK_ULONG          ulDataLen,   /* bytes of data to digest */
+ CK_BYTE_PTR       pDigest,     /* gets the message digest */
+ CK_ULONG_PTR      pulDigestLen /* gets digest length */
+)
+{
+    (void)hSession;
+    (void)pData;
+    (void)ulDataLen;
+    (void)pDigest;
+    (void)pulDigestLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DigestUpdate continues a multiple-part message-digesting
+ * operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DigestUpdate)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_BYTE_PTR       pPart,    /* data to be digested */
+ CK_ULONG          ulPartLen /* bytes of data to be digested */
+)
+{
+    (void)hSession;
+    (void)pPart;
+    (void)ulPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DigestKey continues a multi-part message-digesting
+ * operation, by digesting the value of a secret key as part of
+ * the data already digested.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DigestKey)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_OBJECT_HANDLE  hKey      /* secret key to digest */
+)
+{
+    (void)hSession;
+    (void)hKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DigestFinal finishes a multiple-part message-digesting
+ * operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DigestFinal)
+
+(CK_SESSION_HANDLE hSession,    /* the session's handle */
+ CK_BYTE_PTR       pDigest,     /* gets the message digest */
+ CK_ULONG_PTR      pulDigestLen /* gets byte count of digest */
+)
+{
+    (void)hSession;
+    (void)pDigest;
+    (void)pulDigestLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Signing and MACing */
+
+/* C_SignInit initializes a signature (private key encryption)
+ * operation, where the signature is (will be) an appendix to
+ * the data, and plaintext cannot be recovered from the
+ * signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SignInit)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism, /* the signature mechanism */
+ CK_OBJECT_HANDLE  hKey        /* handle of signature key */
+)
+{
+    DEBUG("C_SignInit START");
+    (void)pMechanism; // TODO: Do something with this?
+
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    // Session ID == Slot Number
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken& sToken = sSlotPtr->getToken();
+
+    PKCS11_SfSession& sSession = sToken.getSession();
+
+    // TODO: handle null ptr
+    const SfKey* sKeyPtr = sSession.getKey(hKey);
+    if(!sKeyPtr)
+    {
+        DEBUG("BAD ARGUMENT: hObject " << std::dec << hKey);
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    sSession.initSigning(hKey);
+
+    return CKR_OK;
+}
+
+/* C_Sign signs (encrypts with private key) data in a single
+ * part, where the signature is (will be) an appendix to the
+ * data, and plaintext cannot be recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_Sign)
+
+(CK_SESSION_HANDLE hSession,       /* the session's handle */
+ CK_BYTE_PTR       pData,          /* the data to sign */
+ CK_ULONG          ulDataLen,      /* count of bytes to sign */
+ CK_BYTE_PTR       pSignature,     /* gets the signature */
+ CK_ULONG_PTR      pulSignatureLen /* gets signature length */
+)
+{
+    DEBUG("C_Sign");
+
+    if(!SfModule)
+    {
+        return CKR_CRYPTOKI_NOT_INITIALIZED;
+    }
+
+    // Session ID == Slot Number
+    PKCS11_SfSlot* sSlotPtr = SfModule->getSlot(hSession);
+    if(!sSlotPtr)
+    {
+        return CKR_ARGUMENTS_BAD;
+    }
+
+    PKCS11_SfToken& sToken = sSlotPtr->getToken();
+
+    PKCS11_SfSession& sSession = sToken.getSession();
+    bool sIsSuccess            = sSession.doSigning(pData, ulDataLen, pSignature, *pulSignatureLen);
+
+    return sIsSuccess ? CKR_OK : CKR_GENERAL_ERROR;
+}
+
+/* C_SignUpdate continues a multiple-part signature operation,
+ * where the signature is (will be) an appendix to the data,
+ * and plaintext cannot be recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SignUpdate)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_BYTE_PTR       pPart,    /* the data to sign */
+ CK_ULONG          ulPartLen /* count of bytes to sign */
+)
+{
+    DEBUG("C_SignUpdate");
+    (void)hSession;
+    (void)pPart;
+    (void)ulPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_SignFinal finishes a multiple-part signature operation,
+ * returning the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SignFinal)
+
+(CK_SESSION_HANDLE hSession,       /* the session's handle */
+ CK_BYTE_PTR       pSignature,     /* gets the signature */
+ CK_ULONG_PTR      pulSignatureLen /* gets signature length */
+)
+{
+    (void)hSession;
+    (void)pSignature;
+    (void)pulSignatureLen;
+
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_SignRecoverInit initializes a signature operation, where
+ * the data can be recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SignRecoverInit)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism, /* the signature mechanism */
+ CK_OBJECT_HANDLE  hKey        /* handle of the signature key */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_SignRecover signs data in a single operation, where the
+ * data can be recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SignRecover)
+
+(CK_SESSION_HANDLE hSession,       /* the session's handle */
+ CK_BYTE_PTR       pData,          /* the data to sign */
+ CK_ULONG          ulDataLen,      /* count of bytes to sign */
+ CK_BYTE_PTR       pSignature,     /* gets the signature */
+ CK_ULONG_PTR      pulSignatureLen /* gets signature length */
+)
+{
+    (void)hSession;
+    (void)pData;
+    (void)ulDataLen;
+    (void)pSignature;
+    (void)pulSignatureLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Verifying signatures and MACs */
+
+/* C_VerifyInit initializes a verification operation, where the
+ * signature is an appendix to the data, and plaintext cannot
+ * cannot be recovered from the signature (e.g. DSA).
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_VerifyInit)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism, /* the verification mechanism */
+ CK_OBJECT_HANDLE  hKey        /* verification key */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_Verify verifies a signature in a single-part operation,
+ * where the signature is an appendix to the data, and plaintext
+ * cannot be recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_Verify)
+
+(CK_SESSION_HANDLE hSession,      /* the session's handle */
+ CK_BYTE_PTR       pData,         /* signed data */
+ CK_ULONG          ulDataLen,     /* length of signed data */
+ CK_BYTE_PTR       pSignature,    /* signature */
+ CK_ULONG          ulSignatureLen /* signature length*/
+)
+{
+    (void)hSession;
+    (void)pData;
+    (void)ulDataLen;
+    (void)pSignature;
+    (void)ulSignatureLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_VerifyUpdate continues a multiple-part verification
+ * operation, where the signature is an appendix to the data,
+ * and plaintext cannot be recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_VerifyUpdate)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_BYTE_PTR       pPart,    /* signed data */
+ CK_ULONG          ulPartLen /* length of signed data */
+)
+{
+    (void)hSession;
+    (void)pPart;
+    (void)ulPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_VerifyFinal finishes a multiple-part verification
+ * operation, checking the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_VerifyFinal)
+
+(CK_SESSION_HANDLE hSession,      /* the session's handle */
+ CK_BYTE_PTR       pSignature,    /* signature to verify */
+ CK_ULONG          ulSignatureLen /* signature length */
+)
+{
+    (void)hSession;
+    (void)pSignature;
+    (void)ulSignatureLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_VerifyRecoverInit initializes a signature verification
+ * operation, where the data is recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_VerifyRecoverInit)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism, /* the verification mechanism */
+ CK_OBJECT_HANDLE  hKey        /* verification key */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_VerifyRecover verifies a signature in a single-part
+ * operation, where the data is recovered from the signature.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_VerifyRecover)
+
+(CK_SESSION_HANDLE hSession,       /* the session's handle */
+ CK_BYTE_PTR       pSignature,     /* signature to verify */
+ CK_ULONG          ulSignatureLen, /* signature length */
+ CK_BYTE_PTR       pData,          /* gets signed data */
+ CK_ULONG_PTR      pulDataLen      /* gets signed data len */
+)
+{
+    (void)hSession;
+    (void)pSignature;
+    (void)ulSignatureLen;
+    (void)pData;
+    (void)pulDataLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Dual-function cryptographic operations */
+
+/* C_DigestEncryptUpdate continues a multiple-part digesting
+ * and encryption operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DigestEncryptUpdate)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pPart,              /* the plaintext data */
+ CK_ULONG          ulPartLen,          /* plaintext length */
+ CK_BYTE_PTR       pEncryptedPart,     /* gets ciphertext */
+ CK_ULONG_PTR      pulEncryptedPartLen /* gets c-text length */
+)
+{
+    (void)hSession;
+    (void)pPart;
+    (void)ulPartLen;
+    (void)pEncryptedPart;
+    (void)pulEncryptedPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DecryptDigestUpdate continues a multiple-part decryption and
+ * digesting operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DecryptDigestUpdate)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pEncryptedPart,     /* ciphertext */
+ CK_ULONG          ulEncryptedPartLen, /* ciphertext length */
+ CK_BYTE_PTR       pPart,              /* gets plaintext */
+ CK_ULONG_PTR      pulPartLen          /* gets plaintext len */
+)
+{
+    (void)hSession;
+    (void)pEncryptedPart;
+    (void)ulEncryptedPartLen;
+    (void)pPart;
+    (void)pulPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_SignEncryptUpdate continues a multiple-part signing and
+ * encryption operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SignEncryptUpdate)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pPart,              /* the plaintext data */
+ CK_ULONG          ulPartLen,          /* plaintext length */
+ CK_BYTE_PTR       pEncryptedPart,     /* gets ciphertext */
+ CK_ULONG_PTR      pulEncryptedPartLen /* gets c-text length */
+)
+{
+    (void)hSession;
+    (void)pPart;
+    (void)ulPartLen;
+    (void)pEncryptedPart;
+    (void)pulEncryptedPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DecryptVerifyUpdate continues a multiple-part decryption and
+ * verify operation.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DecryptVerifyUpdate)
+
+(CK_SESSION_HANDLE hSession,           /* session's handle */
+ CK_BYTE_PTR       pEncryptedPart,     /* ciphertext */
+ CK_ULONG          ulEncryptedPartLen, /* ciphertext length */
+ CK_BYTE_PTR       pPart,              /* gets plaintext */
+ CK_ULONG_PTR      pulPartLen          /* gets p-text length */
+)
+{
+    (void)hSession;
+    (void)pEncryptedPart;
+    (void)ulEncryptedPartLen;
+    (void)pPart;
+    (void)pulPartLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Key management */
+
+/* C_GenerateKey generates a secret key, creating a new key
+ * object.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GenerateKey)
+
+(CK_SESSION_HANDLE    hSession,   /* the session's handle */
+ CK_MECHANISM_PTR     pMechanism, /* key generation mech. */
+ CK_ATTRIBUTE_PTR     pTemplate,  /* template for new key */
+ CK_ULONG             ulCount,    /* # of attrs in template */
+ CK_OBJECT_HANDLE_PTR phKey       /* gets handle of new key */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)pTemplate;
+    (void)ulCount;
+    (void)phKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_GenerateKeyPair generates a public-key/private-key pair,
+ * creating new key objects.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GenerateKeyPair)
+
+(CK_SESSION_HANDLE    hSession,                   /* session handle */
+ CK_MECHANISM_PTR     pMechanism,                 /* key-gen mech. */
+ CK_ATTRIBUTE_PTR     pPublicKeyTemplate,         /* template for pub. key */
+ CK_ULONG             ulPublicKeyAttributeCount,  /* # pub. attrs. */
+ CK_ATTRIBUTE_PTR     pPrivateKeyTemplate,        /* template for priv. key */
+ CK_ULONG             ulPrivateKeyAttributeCount, /* # priv.  attrs. */
+ CK_OBJECT_HANDLE_PTR phPublicKey,                /* gets pub. key handle */
+ CK_OBJECT_HANDLE_PTR phPrivateKey                /* gets priv. key handle */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)pPublicKeyTemplate;
+    (void)ulPublicKeyAttributeCount;
+    (void)pPrivateKeyTemplate;
+    (void)ulPrivateKeyAttributeCount;
+    (void)phPublicKey;
+    (void)phPrivateKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_WrapKey wraps (i.e., encrypts) a key. */
+CK_DECLARE_FUNCTION(CK_RV, C_WrapKey)
+
+(CK_SESSION_HANDLE hSession,        /* the session's handle */
+ CK_MECHANISM_PTR  pMechanism,      /* the wrapping mechanism */
+ CK_OBJECT_HANDLE  hWrappingKey,    /* wrapping key */
+ CK_OBJECT_HANDLE  hKey,            /* key to be wrapped */
+ CK_BYTE_PTR       pWrappedKey,     /* gets wrapped key */
+ CK_ULONG_PTR      pulWrappedKeyLen /* gets wrapped key size */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hWrappingKey;
+    (void)hKey;
+    (void)pWrappedKey;
+    (void)pulWrappedKeyLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_UnwrapKey unwraps (decrypts) a wrapped key, creating a new
+ * key object.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_UnwrapKey)
+
+(CK_SESSION_HANDLE    hSession,         /* session's handle */
+ CK_MECHANISM_PTR     pMechanism,       /* unwrapping mech. */
+ CK_OBJECT_HANDLE     hUnwrappingKey,   /* unwrapping key */
+ CK_BYTE_PTR          pWrappedKey,      /* the wrapped key */
+ CK_ULONG             ulWrappedKeyLen,  /* wrapped key len */
+ CK_ATTRIBUTE_PTR     pTemplate,        /* new key template */
+ CK_ULONG             ulAttributeCount, /* template length */
+ CK_OBJECT_HANDLE_PTR phKey             /* gets new handle */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hUnwrappingKey;
+    (void)pWrappedKey;
+    (void)ulWrappedKeyLen;
+    (void)pTemplate;
+    (void)ulAttributeCount;
+    (void)phKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_DeriveKey derives a key from a base key, creating a new key
+ * object.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_DeriveKey)
+
+(CK_SESSION_HANDLE    hSession,         /* session's handle */
+ CK_MECHANISM_PTR     pMechanism,       /* key deriv. mech. */
+ CK_OBJECT_HANDLE     hBaseKey,         /* base key */
+ CK_ATTRIBUTE_PTR     pTemplate,        /* new key template */
+ CK_ULONG             ulAttributeCount, /* template length */
+ CK_OBJECT_HANDLE_PTR phKey             /* gets new handle */
+)
+{
+    (void)hSession;
+    (void)pMechanism;
+    (void)hBaseKey;
+    (void)pTemplate;
+    (void)ulAttributeCount;
+    (void)phKey;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Random number generation */
+
+/* C_SeedRandom mixes additional seed material into the token's
+ * random number generator.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_SeedRandom)
+
+(CK_SESSION_HANDLE hSession, /* the session's handle */
+ CK_BYTE_PTR       pSeed,    /* the seed material */
+ CK_ULONG          ulSeedLen /* length of seed material */
+)
+{
+    (void)hSession;
+    (void)pSeed;
+    (void)ulSeedLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_GenerateRandom generates random data. */
+CK_DECLARE_FUNCTION(CK_RV, C_GenerateRandom)
+
+(CK_SESSION_HANDLE hSession,   /* the session's handle */
+ CK_BYTE_PTR       RandomData, /* receives the random data */
+ CK_ULONG          ulRandomLen /* # of bytes to generate */
+)
+{
+    (void)hSession;
+    (void)RandomData;
+    (void)ulRandomLen;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* Parallel function management */
+
+/* C_GetFunctionStatus is a legacy function{} it obtains an
+ * updated status of a function running in parallel with an
+ * application.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_GetFunctionStatus)
+
+(CK_SESSION_HANDLE hSession /* the session's handle */
+)
+{
+    (void)hSession;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_CancelFunction is a legacy function{} it cancels a function
+ * running in parallel.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_CancelFunction)
+
+(CK_SESSION_HANDLE hSession /* the session's handle */
+)
+{
+    (void)hSession;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}
+
+/* C_WaitForSlotEvent waits for a slot event (token insertion,
+ * removal, etc.) to occur.
+ */
+CK_DECLARE_FUNCTION(CK_RV, C_WaitForSlotEvent)
+
+(CK_FLAGS       flags,   /* blocking/nonblocking flag */
+ CK_SLOT_ID_PTR pSlot,   /* location that receives the slot ID */
+ CK_VOID_PTR    pRserved /* reserved.  Should be NULL_PTR */
+)
+{
+    (void)flags;
+    (void)pSlot;
+    (void)pRserved;
+    return CKR_FUNCTION_NOT_SUPPORTED;
+}

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-client.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-client.h
@@ -1,0 +1,57 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <bitset>
+#include <iostream>
+#include <openssl/crypto.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifndef _PKCS11_SF_CLIENT_H
+#define _PKCS11_SF_CLIENT_H
+
+// Required definitions for PKCS11 files
+#define CK_PTR *
+#define CK_DECLARE_FUNCTION(returnType, name) returnType name
+#define CK_DECLARE_FUNCTION_POINTER(returnType, name) returnType(*name)
+#define CK_CALLBACK_FUNCTION(returnType, name) returnType(*name)
+
+#ifndef NULL_PTR
+#define NULL_PTR 0
+#endif
+
+#include "pkcs11/pkcs11.h"
+
+enum
+{
+    CryptokiVersionMajor       = 2,
+    CryptokiVersionMinor       = 40,
+    Pkcs11SfClientVersionMajor = 0,
+    Pkcs11SfClientVersionMinor = 1,
+};
+
+// Slots:
+// Only expose a single slot to the application
+enum
+{
+    TotalNumberOfSlots     = 1,
+    MaxPasswordLength      = 1024,
+    PasswordAllocationSize = MaxPasswordLength + 1, // null termination
+};
+
+
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-json.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-json.cpp
@@ -1,0 +1,114 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+#include <json-c/json.h>
+#include <sf_utils/sf_utils.h>
+#include <string>
+#include <vector>
+
+#include "pkcs11-sf-json.h"
+#include "pkcs11-sf-types.h"
+
+static bool
+decodeJsonString(json_object* jsonParentParm, const std::string& tagParm, std::string& valueParm)
+{
+    bool sIsSuccess = false;
+    valueParm.clear();
+    if(jsonParentParm)
+    {
+        json_object* sJsonChild = NULL;
+        json_object_object_get_ex(jsonParentParm, tagParm.c_str(), &sJsonChild);
+
+        if(sJsonChild)
+        {
+            const char* sJsonString = json_object_get_string(sJsonChild);
+            if(sJsonString)
+            {
+                valueParm  = std::string(sJsonString);
+                sIsSuccess = true;
+            }
+        }
+    }
+    return sIsSuccess;
+}
+
+static bool
+decodeJsonArray(json_object* jsonParentParm, const std::string& tagParm, json_object*& valueParm)
+{
+    bool sIsSuccess = false;
+    if(jsonParentParm)
+    {
+        json_object* sJsonChild = NULL;
+        json_object_object_get_ex(jsonParentParm, tagParm.c_str(), &sJsonChild);
+
+        if(sJsonChild)
+        {
+            if(json_object_is_type(sJsonChild, json_type_array))
+            {
+                valueParm = sJsonChild;
+            }
+        }
+    }
+    return sIsSuccess;
+}
+
+bool ParseJsonConfig(const std::string& jsonPath, PKCS11_SF_SESSION_CONFIG& configParm)
+{
+    std::vector<uint8_t> sJsonData;
+
+    bool sIsSuccess = ReadFile(jsonPath, sJsonData);
+
+    std::string sJsonString((char*)sJsonData.data(), (char*)sJsonData.data() + sJsonData.size());
+
+    struct json_object* sRootObject = json_tokener_parse(sJsonString.c_str());
+
+    if(sRootObject)
+    {
+        sIsSuccess &= decodeJsonString(sRootObject, SfJsonKey_Url, configParm.mUrl);
+        sIsSuccess &= decodeJsonString(sRootObject, SfJsonKey_Epwd, configParm.mEpwdPath);
+        sIsSuccess &= decodeJsonString(
+            sRootObject, SfJsonKey_PrivateKeyPath, configParm.mPrivateKeyPath);
+
+        json_object* sArray = NULL;
+        decodeJsonArray(sRootObject, SfJsonKey_ProjectArray, sArray);
+        if(sArray)
+        {
+            for(std::size_t i = 0; i < json_object_array_length(sArray); i++)
+            {
+                PKCS11_SF_SESSION_PROJECTS sProject;
+
+                sIsSuccess &= decodeJsonString(
+                    json_object_array_get_idx(sArray, i), SfJsonKey_ProjectName, sProject.mName);
+
+                sIsSuccess &= decodeJsonString(
+                    json_object_array_get_idx(sArray, i), SfJsonKey_ProjectType, sProject.mKeyType);
+
+                sIsSuccess &= decodeJsonString(json_object_array_get_idx(sArray, i),
+                                               SfJsonKey_HashAlgorithm,
+                                               sProject.mHashAlgorithm);
+
+                configParm.mProjects.push_back(sProject);
+
+#ifdef DEBUG
+                std::cout << "JSON Parsed: " << sProject.mName << std::endl;
+#endif
+            }
+        }
+
+        json_object_put(sRootObject);
+    }
+    return sIsSuccess;
+}

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-json.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-json.h
@@ -1,0 +1,39 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string>
+#include <vector>
+
+#ifndef _PKCS11_SF_JSON_H
+#define _PKCS11_SF_JSON_H
+
+struct PKCS11_SF_SESSION_PROJECTS
+{
+    std::string mName;
+    std::string mKeyType;
+    std::string mHashAlgorithm;
+};
+
+struct PKCS11_SF_SESSION_CONFIG
+{
+    std::string                             mUrl;
+    std::vector<PKCS11_SF_SESSION_PROJECTS> mProjects;
+    std::string                             mEpwdPath;
+    std::string                             mPrivateKeyPath;
+};
+
+bool ParseJsonConfig(const std::string& jsonPath, PKCS11_SF_SESSION_CONFIG& configParm);
+
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-module.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-module.cpp
@@ -1,0 +1,226 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <sf_utils/sf_utils.h>
+#include <string.h>
+
+#include "pkcs11-sf-json.h"
+#include "pkcs11-sf-types.h"
+
+#include "pkcs11-sf-module.h"
+
+PKCS11_SfModule::PKCS11_SfModule()
+: mManufacturerID(SfModuleManufacturer)
+, mLibraryDescription(SfModuleDescription)
+, mSlot(mSfClientSession, mObjects)
+{
+    mCryptokiVersion.major = ModuleCryptokiVersionMajor;
+    mCryptokiVersion.minor = ModuleCryptokiVersionMinor;
+    mLibraryVersion.major  = ModuleLibraryVersionMajor;
+    mLibraryVersion.minor  = ModuleLibraryVersionMinor;
+    // For now, hardcoded to only have one slot.
+}
+
+PKCS11_SfModule::~PKCS11_SfModule() {}
+
+PKCS11_SfSlot* PKCS11_SfModule::getSlot(uint64_t slotIdxParm)
+{
+    if(slotIdxParm < 1)
+    {
+        return &mSlot;
+    }
+    return NULL;
+}
+
+CK_FLAGS PKCS11_SfModule::getFlags() const
+{
+    CK_FLAGS sFlags = 0;
+    return sFlags;
+}
+
+void PKCS11_SfModule::getDescription(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const
+{
+    memset(dstParm, ' ', sizeParm);
+    memcpy(dstParm, mLibraryDescription.c_str(), std::min(sizeParm, mLibraryDescription.size()));
+}
+
+void PKCS11_SfModule::getManufacturerId(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const
+{
+    memset(dstParm, ' ', sizeParm);
+    memcpy(dstParm, mManufacturerID.c_str(), std::min(sizeParm, mManufacturerID.size()));
+}
+
+CK_VERSION PKCS11_SfModule::getCryptokiVersion() const { return mCryptokiVersion; }
+
+CK_VERSION PKCS11_SfModule::getLibraryVersion() const { return mLibraryVersion; }
+
+bool PKCS11_SfModule::openServerConnection(std::string urlParm,
+                                           std::string epwdParm,
+                                           std::string pkeyParm)
+{
+
+    // if(mServerPassword.empty())
+    //    return false;
+
+    mUrl            = urlParm;
+    mEpwdPath       = epwdParm;
+    mPrivateKeyPath = pkeyParm;
+
+    sf_client::ServerInfoV1 sSfServerV1;
+    sSfServerV1.mCurlDebug      = false;
+    sSfServerV1.mPasswordPtr    = mServerPassword.c_str();
+    sSfServerV1.mPrivateKeyPath = mPrivateKeyPath;
+    sSfServerV1.mEpwdPath       = mEpwdPath;
+    sSfServerV1.mUrl            = mUrl;
+#ifdef DEBUG
+    sSfServerV1.mVerbose = true;
+#else
+    sSfServerV1.mVerbose = false;
+#endif
+
+    sf_client::rc sRc = sf_client::connectToServer(sSfServerV1, mSfClientSession);
+
+#ifdef DEBUG
+    std::cout << "Open Connection RC: " << std::hex << sRc << std::dec << std::endl;
+    if(sf_client::success != sRc)
+    {
+        // std::cout << "Password " << mServerPassword << std::endl;
+        std::cout << "PrivateKeyPath " << mPrivateKeyPath << std::endl;
+        std::cout << "Url " << mUrl << std::endl;
+    }
+#endif
+
+    return sf_client::success == sRc;
+}
+
+bool PKCS11_SfModule::initObjects(const PKCS11_SF_SESSION_CONFIG& configParm)
+{
+
+    // For each project name, look up the public key on the server
+    for(uint64_t sIdx = 0; sIdx < configParm.mProjects.size(); sIdx++)
+    {
+        const PKCS11_SF_SESSION_PROJECTS& sProject = configParm.mProjects[sIdx];
+
+        std::cout << "Query server for project: " << sProject.mName << std::endl;
+
+        sf_client::CommandArgsV1 sArgsV1;
+        sArgsV1.mProject          = "getpubkey";
+        sArgsV1.mComment          = "PKCS11: get pub key to populate library keys";
+        sArgsV1.mExtraServerParms = "-format pem -signproject " + sProject.mName;
+
+        sf_client::CommandResponseV1 sResponse;
+
+        sf_client::rc sRc = sf_client::sendCommandV1(mSfClientSession, sArgsV1, sResponse);
+
+        if(sf_client::success != sRc || 0 != sResponse.mReturnCode)
+        {
+#ifdef DEBUG
+            std::cout << "Deleting project " << sProject.mName << ". Unable to get private key."
+                      << std::endl;
+#endif
+        }
+        else
+        {
+#ifdef DEBUG
+            std::cout << "Found public key for " << sProject.mName << std::endl;
+#endif
+            // Extract the modulus and public exponent
+
+            std::vector<uint8_t> sModulus;
+            std::vector<uint8_t> sPublicExponent;
+
+            BIO* sMemoryBio = BIO_new(BIO_s_mem());
+
+            // Convert the raw output into a string (BIO expects c_str)
+            std::string sPEM(sResponse.mOutput.data(),
+                             sResponse.mOutput.data() + sResponse.mOutput.size());
+            BIO_puts(sMemoryBio, sPEM.c_str());
+            RSA* sPubKey = PEM_read_bio_RSA_PUBKEY(sMemoryBio, NULL, NULL, NULL);
+
+            // FIXME: Add some error handling for NULL pointers
+            const BIGNUM* sModulusBN        = RSA_get0_n(sPubKey);
+            const BIGNUM* sPublicExponentBN = RSA_get0_e(sPubKey);
+
+            // const BIGNUM* sModulusBN        = sPubKey->n;
+            // const BIGNUM* sPublicExponentBN = sPubKey->e;
+
+            sModulus.resize(BN_num_bytes(sModulusBN));
+            BN_bn2bin(sModulusBN, sModulus.data());
+
+            sPublicExponent.resize(BN_num_bytes(sPublicExponentBN));
+            BN_bn2bin(sPublicExponentBN, sPublicExponent.data());
+
+#ifdef DEBUG
+            std::cout << sModulus.size() << " " << sPublicExponent.size() << std::endl;
+
+            for(uint64_t i = 0; i < sModulus.size(); i++)
+            {
+                std::cout << std::hex << (int)sModulus[i] << std::dec << " ";
+            }
+            std::cout << std::endl;
+
+            for(uint64_t i = 0; i < sPublicExponent.size(); i++)
+            {
+                std::cout << std::hex << (int)sPublicExponent[i] << std::dec << " ";
+            }
+            std::cout << std::endl;
+#endif
+
+            if(sPubKey)
+                RSA_free(sPubKey);
+            if(sMemoryBio)
+                BIO_free(sMemoryBio);
+
+            SfKey sPrivateKey(sProject.mName, CKK_RSA, CKM_SHA512_RSA_PKCS, true);
+            sPrivateKey.mModulus        = sModulus;
+            sPrivateKey.mPublicExponent = sPublicExponent;
+            sPrivateKey.mProjectName    = sProject.mName;
+            sPrivateKey.mPublicKeyPEM   = sPEM;
+
+            SfKey sPublicKey(sProject.mName, CKK_RSA, CKM_SHA512_RSA_PKCS, false);
+            sPublicKey.mModulus        = sModulus;
+            sPublicKey.mPublicExponent = sPublicExponent;
+            sPublicKey.mProjectName    = sProject.mName;
+            sPublicKey.mPublicKeyPEM   = sPEM;
+
+            mObjects.push_back(sPrivateKey);
+            mObjects.push_back(sPublicKey);
+        }
+    }
+    std::cout << "Found " << std::dec << mObjects.size() << " objects" << std::endl;
+    return !mObjects.empty();
+}
+
+bool PKCS11_SfModule::closeServerConnection()
+{
+    sf_client::disconnect(mSfClientSession);
+    return true;
+}
+
+bool PKCS11_SfModule::promptPassword()
+{
+    char sPassword[1024];
+
+    uint64_t sBytesWritten = 0;
+    bool     sIsSuccess    = GetPassword(sPassword, sizeof(sPassword), sBytesWritten, false);
+
+    mServerPassword = std::string(sPassword, sPassword + sBytesWritten);
+
+    return sIsSuccess;
+}
+
+const std::string& PKCS11_SfModule::getPassword() const { return mServerPassword; }

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-module.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-module.h
@@ -1,0 +1,71 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "pkcs11-sf-slot.h"
+
+#ifndef _PKCS11_SF_MODULE_H
+#define _PKCS11_SF_MODULE_H
+
+struct PKCS11_SF_SESSION_CONFIG;
+
+class PKCS11_SfModule
+{
+  public:
+    PKCS11_SfModule();
+    ~PKCS11_SfModule();
+
+    CK_FLAGS getFlags() const;
+
+    void getDescription(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const;
+
+    void getManufacturerId(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const;
+
+    CK_VERSION getCryptokiVersion() const;
+
+    CK_VERSION getLibraryVersion() const;
+
+    bool promptPassword();
+
+    const std::string& getPassword() const;
+
+    bool openServerConnection(std::string urlParm, std::string epwdParm, std::string pkeyParm);
+    bool closeServerConnection();
+
+    bool initObjects(const PKCS11_SF_SESSION_CONFIG& configParm);
+
+    enum
+    {
+        mNumberOfSlots = 1,
+    };
+
+    PKCS11_SfSlot* getSlot(uint64_t slotIdxParm);
+
+  protected:
+    CK_VERSION  mCryptokiVersion;
+    std::string mManufacturerID;
+    std::string mLibraryDescription;
+    CK_VERSION  mLibraryVersion;
+
+    PKCS11_SfSlot mSlot;
+
+    std::string        mServerPassword;
+    sf_client::Session mSfClientSession;
+    std::string        mUrl;
+    std::string        mEpwdPath;
+    std::string        mPrivateKeyPath;
+
+    std::vector<SfKey> mObjects;
+};
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-object.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-object.cpp
@@ -1,0 +1,437 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string.h>
+
+#include "pkcs11-sf-object.h"
+
+template <class primitive>
+void Attribute_GetPrimitive(const primitive& src, CK_VOID_PTR dst, CK_ULONG& length)
+{
+    if(NULL_PTR != dst && length >= sizeof(primitive))
+    {
+        *(primitive*)dst = src;
+    }
+    length = sizeof(primitive);
+}
+
+void Attribute_GetBool(const bool& src, CK_VOID_PTR dst, CK_ULONG& length)
+{
+    if(NULL_PTR != dst && length >= sizeof(CK_BBOOL))
+    {
+        *(CK_BBOOL*)dst = src ? CK_TRUE : CK_FALSE;
+    }
+    length = sizeof(CK_BBOOL);
+}
+
+#define Attribute_GetULong Attribute_GetPrimitive<CK_ULONG>
+
+template <class type>
+void Attribute_GetVector(const std::vector<type>& src, CK_VOID_PTR dst, CK_ULONG& length)
+{
+    if(NULL_PTR != dst && length >= src.size())
+    {
+        memcpy(dst, src.data(), src.size() * sizeof(type));
+    }
+    length = src.size();
+}
+
+#define Attribute_GetBytes Attribute_GetVector<uint8_t>
+
+void Attribute_GetString(const std::string& src, CK_VOID_PTR dst, CK_ULONG& length)
+{
+    if(NULL_PTR != dst && length >= src.size())
+    {
+        memcpy(dst, src.data(), src.size());
+    }
+    length = src.size();
+}
+
+void Pkcs11Object::getAttribute(CK_ATTRIBUTE_TYPE attribute,
+                                CK_VOID_PTR       dst,
+                                CK_ULONG&         length) const
+{
+    switch(attribute)
+    {
+    case CKA_CLASS:
+        Attribute_GetULong(mObjectClass, dst, length);
+        break;
+    case CKA_TOKEN:
+        Attribute_GetBool(mToken, dst, length);
+        break;
+    case CKA_PRIVATE:
+        Attribute_GetBool(mPrivate, dst, length);
+        break;
+    case CKA_MODIFIABLE:
+        Attribute_GetBool(mModifiable, dst, length);
+        break;
+    case CKA_LABEL:
+        Attribute_GetString(mLabel, dst, length);
+        break;
+    case CKA_COPYABLE:
+        Attribute_GetBool(mCopyable, dst, length);
+        break;
+    case CKA_DESTROYABLE:
+        Attribute_GetBool(mDestroyable, dst, length);
+        break;
+    default:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+    };
+}
+
+void Pkcs11Storage::getAttribute(CK_ATTRIBUTE_TYPE attribute,
+                                 CK_VOID_PTR       dst,
+                                 CK_ULONG&         length) const
+{
+    switch(attribute)
+    {
+    case CKA_APPLICATION:
+        Attribute_GetString(mApplication, dst, length);
+        break;
+    case CKA_OBJECT_ID:
+        Attribute_GetBytes(mObjectId, dst, length);
+        break;
+    case CKA_VALUE:
+        Attribute_GetBytes(mValue, dst, length);
+        break;
+    default:
+        Pkcs11Object::getAttribute(attribute, dst, length);
+        break;
+    };
+}
+
+void Pkcs11Key::getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const
+{
+    switch(attribute)
+    {
+    case CKA_KEY_TYPE:
+        Attribute_GetULong(mKeyType, dst, length);
+        break;
+    case CKA_ID:
+        Attribute_GetBytes(mId, dst, length);
+        break;
+    case CKA_START_DATE:
+    case CKA_END_DATE:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+    case CKA_DERIVE:
+        Attribute_GetBool(mDerive, dst, length);
+        break;
+    case CKA_LOCAL:
+        Attribute_GetBool(mLocal, dst, length);
+        break;
+    case CKA_MECHANISM_TYPE:
+        Attribute_GetULong(mKeyGenMechanism, dst, length);
+        break;
+    case CKA_ALLOWED_MECHANISMS:
+        Attribute_GetVector<CK_MECHANISM_TYPE>(mAllowedMechanisms, dst, length);
+        break;
+    default:
+        Pkcs11Storage::getAttribute(attribute, dst, length);
+        break;
+    };
+}
+
+Pkcs11PrivateKey::Pkcs11PrivateKey()
+: Pkcs11Key()
+{
+    mObjectClass = CKO_PRIVATE_KEY;
+}
+void Pkcs11PrivateKey::getAttribute(CK_ATTRIBUTE_TYPE attribute,
+                                    CK_VOID_PTR       dst,
+                                    CK_ULONG&         length) const
+{
+    switch(attribute)
+    {
+    case CKA_SUBJECT:
+        Attribute_GetBytes(mSubject, dst, length);
+        break;
+    case CKA_SENSITIVE:
+        Attribute_GetBool(mSensitive, dst, length);
+        break;
+    case CKA_DECRYPT:
+        Attribute_GetBool(mDecrypt, dst, length);
+        break;
+    case CKA_SIGN:
+        Attribute_GetBool(mSign, dst, length);
+        break;
+    case CKA_SIGN_RECOVER:
+        Attribute_GetBool(mSignRecover, dst, length);
+        break;
+    case CKA_UNWRAP:
+        Attribute_GetBool(mUnwrap, dst, length);
+        break;
+    case CKA_EXTRACTABLE:
+        Attribute_GetBool(mExtractable, dst, length);
+        break;
+    case CKA_ALWAYS_SENSITIVE:
+        Attribute_GetBool(mAlwaysSensitive, dst, length);
+        break;
+    case CKA_NEVER_EXTRACTABLE:
+        Attribute_GetBool(mNeverExtractable, dst, length);
+        break;
+    case CKA_WRAP_WITH_TRUSTED:
+        Attribute_GetBool(mWrapWithTrusted, dst, length);
+        break;
+    case CKA_UNWRAP_TEMPLATE:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+    case CKA_ALWAYS_AUTHENTICATE:
+        Attribute_GetBool(mAlwaysAuthenticate, dst, length);
+        break;
+    case CKA_PUBLIC_KEY_INFO:
+        Attribute_GetBytes(mPublicKeyInfo, dst, length);
+        break;
+
+    default:
+        Pkcs11Key::getAttribute(attribute, dst, length);
+        break;
+    }
+}
+
+void Pkcs11PublicKey::getAttribute(CK_ATTRIBUTE_TYPE attribute,
+                                   CK_VOID_PTR       dst,
+                                   CK_ULONG&         length) const
+{
+    switch(attribute)
+    {
+    case CKA_SUBJECT:
+        Attribute_GetBytes(mSubject, dst, length);
+        break;
+    case CKA_ENCRYPT:
+        Attribute_GetBool(mEncrypt, dst, length);
+        break;
+    case CKA_VERIFY:
+        Attribute_GetBool(mVerify, dst, length);
+        break;
+    case CKA_VERIFY_RECOVER:
+        Attribute_GetBool(mVerifyRecover, dst, length);
+        break;
+    case CKA_WRAP:
+        Attribute_GetBool(mWrap, dst, length);
+        break;
+    case CKA_TRUSTED:
+        Attribute_GetBool(mTrusted, dst, length);
+        break;
+    case CKA_WRAP_TEMPLATE:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+    case CKA_PUBLIC_KEY_INFO:
+        Attribute_GetBytes(mPublicKeyInfo, dst, length);
+        break;
+
+    default:
+        Pkcs11Key::getAttribute(attribute, dst, length);
+        break;
+    }
+}
+
+void Pkcs11RsaKey::getAttribute(CK_ATTRIBUTE_TYPE attribute,
+                                CK_VOID_PTR       dst,
+                                CK_ULONG&         length) const
+{
+    switch(attribute)
+    {
+    case CKA_SUBJECT:
+        Attribute_GetBytes(mSubject, dst, length);
+        break;
+    case CKA_SENSITIVE:
+        Attribute_GetBool(mSensitive, dst, length);
+        break;
+    case CKA_DECRYPT:
+        Attribute_GetBool(mDecrypt, dst, length);
+        break;
+    case CKA_SIGN:
+        Attribute_GetBool(mSign, dst, length);
+        break;
+    case CKA_SIGN_RECOVER:
+        Attribute_GetBool(mSignRecover, dst, length);
+        break;
+    case CKA_UNWRAP:
+        Attribute_GetBool(mUnwrap, dst, length);
+        break;
+    case CKA_EXTRACTABLE:
+        Attribute_GetBool(mExtractable, dst, length);
+        break;
+    case CKA_ALWAYS_SENSITIVE:
+        Attribute_GetBool(mAlwaysSensitive, dst, length);
+        break;
+    case CKA_NEVER_EXTRACTABLE:
+        Attribute_GetBool(mNeverExtractable, dst, length);
+        break;
+    case CKA_WRAP_WITH_TRUSTED:
+        Attribute_GetBool(mWrapWithTrusted, dst, length);
+        break;
+    case CKA_UNWRAP_TEMPLATE:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+    case CKA_ALWAYS_AUTHENTICATE:
+        Attribute_GetBool(mAlwaysAuthenticate, dst, length);
+        break;
+    case CKA_PUBLIC_KEY_INFO:
+        Attribute_GetBytes(mPublicKeyInfo, dst, length);
+        break;
+    case CKA_ENCRYPT:
+        Attribute_GetBool(mEncrypt, dst, length);
+        break;
+    case CKA_VERIFY:
+        Attribute_GetBool(mVerify, dst, length);
+        break;
+    case CKA_VERIFY_RECOVER:
+        Attribute_GetBool(mVerifyRecover, dst, length);
+        break;
+    case CKA_WRAP:
+        Attribute_GetBool(mWrap, dst, length);
+        break;
+    case CKA_TRUSTED:
+        Attribute_GetBool(mTrusted, dst, length);
+        break;
+    case CKA_WRAP_TEMPLATE:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+
+    default:
+        Pkcs11Key::getAttribute(attribute, dst, length);
+        break;
+    }
+}
+
+void Pkcs11SecretKey::getAttribute(CK_ATTRIBUTE_TYPE attribute,
+                                   CK_VOID_PTR       dst,
+                                   CK_ULONG&         length) const
+{
+    switch(attribute)
+    {
+
+    case CKA_SENSITIVE:
+        Attribute_GetBool(mSensitive, dst, length);
+        break;
+    case CKA_ENCRYPT:
+        Attribute_GetBool(mEncrypt, dst, length);
+        break;
+    case CKA_DECRYPT:
+        Attribute_GetBool(mDecrypt, dst, length);
+        break;
+    case CKA_SIGN:
+        Attribute_GetBool(mSign, dst, length);
+        break;
+    case CKA_VERIFY:
+        Attribute_GetBool(mVerify, dst, length);
+        break;
+    case CKA_WRAP:
+        Attribute_GetBool(mWrap, dst, length);
+        break;
+    case CKA_UNWRAP:
+        Attribute_GetBool(mUnwrap, dst, length);
+        break;
+    case CKA_EXTRACTABLE:
+        Attribute_GetBool(mExtractable, dst, length);
+        break;
+    case CKA_ALWAYS_SENSITIVE:
+        Attribute_GetBool(mAlwaysSensitive, dst, length);
+        break;
+    case CKA_NEVER_EXTRACTABLE:
+        Attribute_GetBool(mNeverExtractable, dst, length);
+        break;
+    case CKA_CHECK_VALUE:
+        Attribute_GetBytes(mChecksum, dst, length);
+        break;
+    case CKA_WRAP_WITH_TRUSTED:
+        Attribute_GetBool(mWrapWithTrusted, dst, length);
+        break;
+    case CKA_UNWRAP_TEMPLATE:
+    case CKA_WRAP_TEMPLATE:
+        length = CK_UNAVAILABLE_INFORMATION;
+        break;
+    default:
+        Pkcs11Key::getAttribute(attribute, dst, length);
+        break;
+    }
+}
+
+SfKey::SfKey(std::string       projectParm,
+             CK_KEY_TYPE       keyTypeParm,
+             CK_MECHANISM_TYPE allowedMechanismParm,
+             bool              isPrivateParm)
+: mProjectName(projectParm)
+{
+    if(isPrivateParm)
+        mObjectClass = CKO_PRIVATE_KEY;
+    else
+    {
+        mObjectClass = CKO_PUBLIC_KEY;
+    }
+
+    // Object
+    mPrivate     = true;
+    mModifiable  = false;
+    mLabel       = projectParm;
+    mCopyable    = false;
+    mDestroyable = false;
+
+    // Storage
+    mApplication.clear();
+    mObjectId.clear();
+    mValue.clear();
+
+    // Key
+    mKeyType = keyTypeParm;
+    mId = std::vector<uint8_t>((uint8_t*)mLabel.data(), (uint8_t*)mLabel.data() + mLabel.size());
+    memset(&mStartDate, 0, sizeof(mStartDate));
+    memset(&mEndDate, 0, sizeof(mEndDate));
+    mDerive = false;
+    mLocal  = false;
+    mAllowedMechanisms.push_back(allowedMechanismParm);
+
+    // Private Key
+    mSubject.clear();
+    mSensitive          = true;
+    mDecrypt            = false;
+    mSign               = true;
+    mSignRecover        = false;
+    mUnwrap             = false;
+    mExtractable        = false;
+    mAlwaysSensitive    = true;
+    mNeverExtractable   = true;
+    mWrapWithTrusted    = false;
+    mAlwaysAuthenticate = false;
+    mPublicKeyInfo.clear();
+
+    mEncrypt       = false;
+    mVerify        = false;
+    mVerifyRecover = false;
+    mWrap          = false;
+    mTrusted       = false;
+
+    mPublicExponent.clear();
+    mModulus.clear();
+}
+
+void SfKey::getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const
+{
+    switch(attribute)
+    {
+    case CKA_MODULUS:
+        Attribute_GetBytes(mModulus, dst, length);
+        break;
+    case CKA_PUBLIC_EXPONENT:
+        Attribute_GetBytes(mPublicExponent, dst, length);
+        break;
+    default:
+        Pkcs11RsaKey::getAttribute(attribute, dst, length);
+        break;
+    }
+}

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-object.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-object.h
@@ -1,0 +1,158 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include "pkcs11-sf-client.h"
+
+#ifndef _PKCS11_SF_OBJECT_H
+#define _PKCS11_SF_OBJECT_H
+
+struct Pkcs11Object
+{
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    CK_OBJECT_CLASS mObjectClass;
+    bool            mToken;
+    bool            mPrivate;
+    bool            mModifiable;
+    std::string     mLabel;
+    bool            mCopyable;
+    bool            mDestroyable;
+};
+
+struct Pkcs11Storage : public Pkcs11Object
+{
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    std::string          mApplication;
+    std::vector<uint8_t> mObjectId;
+    std::vector<uint8_t> mValue;
+};
+
+struct Pkcs11Key : public Pkcs11Storage
+{
+
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    CK_KEY_TYPE                    mKeyType;
+    std::vector<uint8_t>           mId;
+    CK_DATE                        mStartDate;
+    CK_DATE                        mEndDate;
+    bool                           mDerive;
+    bool                           mLocal;
+    CK_MECHANISM_TYPE              mKeyGenMechanism;
+    std::vector<CK_MECHANISM_TYPE> mAllowedMechanisms;
+};
+
+struct Pkcs11RsaKey : Pkcs11Key
+{
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    std::vector<uint8_t> mSubject;
+    bool                 mSensitive;
+    bool                 mDecrypt;
+    bool                 mSign;
+    bool                 mSignRecover;
+    bool                 mUnwrap;
+    bool                 mExtractable;
+    bool                 mAlwaysSensitive;
+    bool                 mNeverExtractable;
+    bool                 mWrapWithTrusted;
+    // CKA_UNWRAP_TEMPLATE
+    bool                 mAlwaysAuthenticate;
+    std::vector<uint8_t> mPublicKeyInfo;
+
+    bool mEncrypt;
+    bool mVerify;
+    bool mVerifyRecover;
+    bool mWrap;
+    bool mTrusted;
+};
+
+struct Pkcs11PrivateKey : public Pkcs11Key
+{
+    Pkcs11PrivateKey();
+
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    std::vector<uint8_t> mSubject;
+    bool                 mSensitive;
+    bool                 mDecrypt;
+    bool                 mSign;
+    bool                 mSignRecover;
+    bool                 mUnwrap;
+    bool                 mExtractable;
+    bool                 mAlwaysSensitive;
+    bool                 mNeverExtractable;
+    bool                 mWrapWithTrusted;
+    // CKA_UNWRAP_TEMPLATE
+    bool                 mAlwaysAuthenticate;
+    std::vector<uint8_t> mPublicKeyInfo;
+};
+
+struct Pkcs11PublicKey : public Pkcs11Key
+{
+
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    std::vector<uint8_t> mSubject;
+    bool                 mEncrypt;
+    bool                 mVerify;
+    bool                 mVerifyRecover;
+    bool                 mWrap;
+    bool                 mTrusted;
+    // CKA_WRAP_TEMPLATE
+    std::vector<uint8_t> mPublicKeyInfo;
+};
+
+struct Pkcs11SecretKey : public Pkcs11Key
+{
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    bool                 mSensitive;
+    bool                 mEncrypt;
+    bool                 mDecrypt;
+    bool                 mSign;
+    bool                 mVerify;
+    bool                 mWrap;
+    bool                 mUnwrap;
+    bool                 mExtractable;
+    bool                 mAlwaysSensitive;
+    bool                 mNeverExtractable;
+    std::vector<uint8_t> mChecksum;
+    bool                 mWrapWithTrusted;
+    // CKA_WRAP_TEMPLATE
+    // CKA_UNWRAP_TEMPLATE
+};
+
+struct SfKey : public Pkcs11RsaKey
+{
+    SfKey(std::string       projectParm,
+          CK_KEY_TYPE       keyTypeParm,
+          CK_MECHANISM_TYPE allowedMechanismsParm,
+          bool              isPrivateParm);
+
+    void getAttribute(CK_ATTRIBUTE_TYPE attribute, CK_VOID_PTR dst, CK_ULONG& length) const;
+
+    std::vector<uint8_t> mModulus;
+    std::vector<uint8_t> mPublicExponent;
+    std::string          mProjectName;
+    std::string          mPublicKeyPEM;
+};
+
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-session.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-session.cpp
@@ -1,0 +1,143 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#include <string.h>
+
+#include "pkcs11-sf-token.h"
+
+#include "pkcs11-sf-session.h"
+
+PKCS11_SfSession::PKCS11_SfSession(PKCS11_SfToken& tokenParm)
+: mToken(tokenParm)
+{
+}
+
+void PKCS11_SfSession::initSearch(CK_ATTRIBUTE_PTR templateParm, CK_ULONG templateCountParm)
+{
+    mFindObjectCurrentIndex = 0;
+    mSearchTemplate         = templateParm;
+    mNumberOfTemplates      = templateCountParm;
+}
+void PKCS11_SfSession::doSearch(CK_OBJECT_HANDLE_PTR dstObjectsParm,
+                                CK_ULONG             dstObjectsSizeParm,
+                                CK_ULONG&            objectsWrittenParm)
+{
+    objectsWrittenParm = 0;
+
+    for(;
+        mFindObjectCurrentIndex < mToken.mObjects.size() && objectsWrittenParm < dstObjectsSizeParm;
+        mFindObjectCurrentIndex++)
+    {
+        bool sMatches = true;
+        for(CK_ULONG i = 0; i < mNumberOfTemplates; i++)
+        {
+            uint8_t  sAttribute[100];
+            CK_ULONG sAttributeLength = sizeof(sAttribute);
+
+            mToken.mObjects[mFindObjectCurrentIndex].getAttribute(
+                mSearchTemplate[i].type, sAttribute, sAttributeLength);
+
+            if(sAttributeLength != mSearchTemplate[i].ulValueLen)
+            {
+                sMatches = false;
+                break;
+            }
+
+            if(0 != memcmp(mSearchTemplate[i].pValue, sAttribute, sAttributeLength))
+            {
+                sMatches = false;
+                break;
+            }
+        }
+
+        if(sMatches)
+        {
+#ifdef DEBUG
+            std::cout << "doSearch MATCH " << std::dec << mFindObjectCurrentIndex << std::endl;
+#endif
+
+            dstObjectsParm[objectsWrittenParm] = mFindObjectCurrentIndex;
+            objectsWrittenParm++;
+        }
+    }
+}
+void PKCS11_SfSession::endSearch()
+{
+    mSearchTemplate    = NULL_PTR;
+    mNumberOfTemplates = 0;
+}
+
+const SfKey* PKCS11_SfSession::getKey(CK_OBJECT_HANDLE handleParm)
+{
+    if(handleParm < mToken.mObjects.size())
+    {
+        return &mToken.mObjects[handleParm];
+    }
+    return NULL;
+}
+
+void PKCS11_SfSession::initSigning(CK_OBJECT_HANDLE keyParm) { mSignKey = keyParm; }
+
+bool PKCS11_SfSession::doSigning(CK_BYTE_PTR srcParm,
+                                 CK_ULONG    srcLengthParm,
+                                 CK_BYTE_PTR dstParm,
+                                 CK_ULONG&   dstLengthParm)
+{
+
+    sf_client::CommandArgsV1 sArgsV1;
+    sArgsV1.mProject = mToken.mObjects[mSignKey].mProjectName;
+
+    sArgsV1.mComment = "PKCS11: Do sign"; // @TODO: Use a meaningful comment
+
+    if(srcLengthParm > 64)
+    {
+        // @TODO More elegantly detect if the OID is included on the source parameter.
+        // Strip off the 19 bytes of OID to enable mkimage
+        sArgsV1.mPayload = std::vector<uint8_t>(srcParm + 19, srcParm + srcLengthParm);
+    }
+    else
+    {
+        // Otherwise shove the sha512 into the vector
+        sArgsV1.mPayload = std::vector<uint8_t>(srcParm, srcParm + srcLengthParm);
+    }
+
+#ifdef DEBUG
+    std::cout << "Source Length " << sArgsV1.mPayload.size() << std::endl;
+#endif
+
+    sf_client::CommandResponseV1 sResponseV1;
+
+    sf_client::rc sRc = sf_client::sendCommandV1(mToken.mSfClientSession, sArgsV1, sResponseV1);
+
+#ifdef DEBUG
+    std::cout << "Do Sign " << sRc << " " << sResponseV1.mReturnCode << std::endl;
+
+    if(sf_client::success == sRc && 0 != sResponseV1.mReturnCode)
+    {
+        std::cout << sResponseV1.mStdOut << std::endl;
+    }
+
+#endif
+
+    if(sRc == sf_client::success && 0 == sResponseV1.mReturnCode)
+    {
+        memcpy(dstParm, sResponseV1.mOutput.data(), sResponseV1.mOutput.size());
+        dstLengthParm = sResponseV1.mOutput.size();
+        return true;
+    }
+    return false;
+}

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-session.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-session.h
@@ -1,0 +1,52 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class PKCS11_SfToken;
+
+#include <sf_client/sf_client.h>
+
+#ifndef _PKCS11_SF_SESSION_H
+#define _PKCS11_SF_SESSION_H
+
+class PKCS11_SfSession
+{
+  public:
+    PKCS11_SfSession(PKCS11_SfToken& tokenParm);
+
+    void initSearch(CK_ATTRIBUTE_PTR templateParm, CK_ULONG templateCountParm);
+    void doSearch(CK_OBJECT_HANDLE_PTR dstObjectsParm,
+                  CK_ULONG             dstObjectsSizeParm,
+                  CK_ULONG&            objectsWrittenParm);
+    void endSearch();
+
+    const SfKey* getKey(CK_OBJECT_HANDLE handleParm);
+
+    void initSigning(CK_OBJECT_HANDLE keyParm);
+    bool doSigning(CK_BYTE_PTR srcParm,
+                   CK_ULONG    srcLengthParm,
+                   CK_BYTE_PTR dstParm,
+                   CK_ULONG&   dstLengthParm);
+
+  protected:
+    PKCS11_SfToken& mToken;
+
+    uint64_t         mFindObjectCurrentIndex;
+    CK_ATTRIBUTE_PTR mSearchTemplate;
+    CK_ULONG         mNumberOfTemplates;
+
+    uint64_t mSignKey = 0;
+};
+
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-slot.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-slot.cpp
@@ -1,0 +1,64 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+#include <string.h>
+
+#include "pkcs11-sf-types.h"
+
+#include "pkcs11-sf-slot.h"
+
+PKCS11_SfSlot::PKCS11_SfSlot(sf_client::Session&       clientSessionParm,
+                             const std::vector<SfKey>& objectParm)
+: mToken(clientSessionParm, objectParm)
+, mId(0)
+, mManufacturerId(SfSlotManufacturer)
+, mDescription(SfSlotDescription)
+, mTokenPresent(true)
+, mRemovableDevice(false)
+, mIsHardwareSlot(false)
+{
+    mHardwareVersion.major = SlotHardwareVersionMajor;
+    mHardwareVersion.minor = SlotHardwareVersionMinor;
+    mFirmwareVersion.major = SlotFirmwareVersionMajor;
+    mFirmwareVersion.minor = SlotFirmwareVersionMinor;
+}
+
+PKCS11_SfToken& PKCS11_SfSlot::getToken() { return mToken; }
+
+CK_FLAGS PKCS11_SfSlot::getFlags() const
+{
+    CK_FLAGS sFlags = 0;
+    sFlags          = sFlags | (mTokenPresent ? CKF_TOKEN_PRESENT : 0);
+    sFlags          = sFlags | (mRemovableDevice ? CKF_REMOVABLE_DEVICE : 0);
+    sFlags          = sFlags | (mIsHardwareSlot ? CKF_HW_SLOT : 0);
+    return sFlags;
+}
+
+void PKCS11_SfSlot::getDescription(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const
+{
+    memset(dstParm, ' ', sizeParm);
+    memcpy(dstParm, mDescription.c_str(), std::min(sizeParm, mDescription.size()));
+}
+
+void PKCS11_SfSlot::getManufacturerId(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const
+{
+    memset(dstParm, ' ', sizeParm);
+    memcpy(dstParm, mManufacturerId.c_str(), std::min(sizeParm, mManufacturerId.size()));
+}
+
+CK_VERSION PKCS11_SfSlot::getHardwareVersion() const { return mHardwareVersion; }
+
+CK_VERSION PKCS11_SfSlot::getFirmwareVersion() const { return mFirmwareVersion; }

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-slot.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-slot.h
@@ -1,0 +1,52 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+struct PKCS11_SF_SESSION_CONFIG;
+
+#include "pkcs11-sf-token.h"
+
+#ifndef _PKCS11_SF_SLOT_H
+#define _PKCS11_SF_SLOT_H
+
+class PKCS11_SfSlot
+{
+  public:
+    PKCS11_SfSlot(sf_client::Session& clientSessionParm, const std::vector<SfKey>& objectParm);
+
+    CK_FLAGS getFlags() const;
+
+    void getDescription(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const;
+
+    void getManufacturerId(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const;
+
+    CK_VERSION getHardwareVersion() const;
+
+    CK_VERSION getFirmwareVersion() const;
+
+    PKCS11_SfToken& getToken();
+
+  protected:
+    PKCS11_SfToken mToken;
+    uint64_t       mId;
+    std::string    mManufacturerId;
+    std::string    mDescription;
+    CK_VERSION     mHardwareVersion;
+    CK_VERSION     mFirmwareVersion;
+    bool           mTokenPresent;
+    bool           mRemovableDevice;
+    bool           mIsHardwareSlot;
+};
+
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-statics.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-statics.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2021 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const char* SfTokenLabel        = "Undefined";
+const char* SfTokenManufacturer = "Undefined";
+const char* SfTokenModel        = "Undefined";
+const char* SfTokenSerialNumber = "Undefined";
+
+const char* SfModuleManufacturer = "Undefined";
+const char* SfModuleDescription  = "Undefined";
+
+const char* SfSlotManufacturer = "Undefined";
+const char* SfSlotDescription  = "Undefined";
+
+const char* SfJsonKey_Url            = "url";
+const char* SfJsonKey_Epwd           = "epwd";
+const char* SfJsonKey_PrivateKeyPath = "private-key";
+const char* SfJsonKey_ProjectArray   = "projects";
+const char* SfJsonKey_ProjectName    = "name";
+const char* SfJsonKey_ProjectType    = "key-type";
+const char* SfJsonKey_HashAlgorithm  = "hash-algorithm";

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-token.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-token.cpp
@@ -1,0 +1,113 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <string.h>
+
+#include "pkcs11-sf-json.h"
+#include "pkcs11-sf-object.h"
+#include "pkcs11-sf-session.h"
+#include "pkcs11-sf-types.h"
+
+#include "pkcs11-sf-token.h"
+
+PKCS11_SfToken::PKCS11_SfToken(sf_client::Session&       clientSessionParm,
+                               const std::vector<SfKey>& objectParm)
+: mLabel(SfTokenLabel)
+, mManufacturerId(SfTokenManufacturer)
+, mModel(SfTokenModel)
+, mSerialNumber(SfTokenSerialNumber)
+, mSessionCount(0)
+, mReadWriteSessionCount(0)
+, mTotalPublicMemory(CK_UNAVAILABLE_INFORMATION)
+, mFreePublicMemory(CK_UNAVAILABLE_INFORMATION)
+, mTotalPrivateMemory(CK_UNAVAILABLE_INFORMATION)
+, mFreePrivateMemory(CK_UNAVAILABLE_INFORMATION)
+, mUtcTime()
+, mTokenInitalized(true)
+, mWriteProtected(true)
+, mSfClientSession(clientSessionParm)
+, mObjects(objectParm)
+, mSession(*this)
+, mSessionInUse(false)
+{
+    mHardwareVersion.major = TokenHardwareVersionMajor;
+    mHardwareVersion.minor = TokenHardwareVersionMinor;
+    mFirmwareVersion.major = TokenFirmwareVersionMajor;
+    mFirmwareVersion.minor = TokenFirmwareVersionMinor;
+}
+
+#define COPY_STRING_TO_TOKEN_INFO(dst, src)                                                        \
+    {                                                                                              \
+        memset((dst), ' ', sizeof((dst)));                                                         \
+        memcpy((dst), (src).c_str(), std::min(sizeof(dst), (src).size()));                         \
+    }
+
+bool PKCS11_SfToken::getTokenInfo(CK_TOKEN_INFO_PTR tokenInfoParm) const
+{
+    if(!tokenInfoParm)
+    {
+        return false;
+    }
+
+    COPY_STRING_TO_TOKEN_INFO(tokenInfoParm->label, mLabel);
+    COPY_STRING_TO_TOKEN_INFO(tokenInfoParm->manufacturerID, mManufacturerId);
+    COPY_STRING_TO_TOKEN_INFO(tokenInfoParm->model, mModel);
+    COPY_STRING_TO_TOKEN_INFO(tokenInfoParm->serialNumber, mSerialNumber);
+
+    // TODO
+    tokenInfoParm->flags = 0;
+    tokenInfoParm->flags = tokenInfoParm->flags | (mTokenInitalized ? CKF_TOKEN_INITIALIZED : 0);
+    tokenInfoParm->flags = tokenInfoParm->flags | (mWriteProtected ? CKF_WRITE_PROTECTED : 0);
+
+    tokenInfoParm->ulMaxSessionCount    = MaxSessionCount;
+    tokenInfoParm->ulSessionCount       = mSessionCount;
+    tokenInfoParm->ulMaxRwSessionCount  = MaxReadWriteSessionCount;
+    tokenInfoParm->ulRwSessionCount     = mReadWriteSessionCount;
+    tokenInfoParm->ulMaxPinLen          = MaxPinLen;
+    tokenInfoParm->ulMinPinLen          = MinPinLen;
+    tokenInfoParm->ulTotalPublicMemory  = mTotalPublicMemory;
+    tokenInfoParm->ulFreePublicMemory   = mFreePublicMemory;
+    tokenInfoParm->ulTotalPrivateMemory = mTotalPrivateMemory;
+    tokenInfoParm->ulFreePrivateMemory  = mFreePrivateMemory;
+    tokenInfoParm->hardwareVersion      = mHardwareVersion;
+    tokenInfoParm->firmwareVersion      = mFirmwareVersion;
+
+    COPY_STRING_TO_TOKEN_INFO(tokenInfoParm->utcTime, mUtcTime);
+
+    return true;
+}
+
+bool PKCS11_SfToken::requestSession()
+{
+    if(!mSessionInUse)
+    {
+        mSessionInUse = true;
+        return true;
+    }
+    return false;
+}
+bool PKCS11_SfToken::releaseSession()
+{
+    if(mSessionInUse)
+    {
+        mSessionInUse = false;
+        return true;
+    }
+    return false;
+}
+
+PKCS11_SfSession& PKCS11_SfToken::getSession() { return mSession; }

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-token.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-token.h
@@ -1,0 +1,62 @@
+struct PKCS11_SF_SESSION_CONFIG;
+
+#include <vector>
+
+#include "pkcs11-sf-object.h"
+#include "pkcs11-sf-session.h"
+
+#ifndef _PKCS11_SF_TOKEN_H
+#define _PKCS11_SF_TOKEN_H
+
+class PKCS11_SfToken
+{
+  public:
+    PKCS11_SfToken(sf_client::Session& clientSessionParm, const std::vector<SfKey>& objectParm);
+
+    enum
+    {
+        MaxSessionCount          = 1,
+        MaxReadWriteSessionCount = 0,
+        MaxPinLen                = 0,
+        MinPinLen                = 0,
+    };
+
+    bool getTokenInfo(CK_TOKEN_INFO_PTR tokenInfoParm) const;
+
+    bool requestSession();
+    bool releaseSession();
+
+    PKCS11_SfSession& getSession();
+
+    friend class PKCS11_SfSession;
+
+  protected:
+    // PKCS defined values
+    std::string mLabel;
+    std::string mManufacturerId;
+    std::string mModel;
+    std::string mSerialNumber;
+    // flags:
+    CK_ULONG    mSessionCount;
+    CK_ULONG    mReadWriteSessionCount;
+    CK_ULONG    mTotalPublicMemory;
+    CK_ULONG    mFreePublicMemory;
+    CK_ULONG    mTotalPrivateMemory;
+    CK_ULONG    mFreePrivateMemory;
+    CK_VERSION  mHardwareVersion;
+    CK_VERSION  mFirmwareVersion;
+    std::string mUtcTime;
+
+    // Skipping over unneeded flags
+    bool mTokenInitalized;
+    bool mWriteProtected;
+
+    // sf_client values
+    sf_client::Session&       mSfClientSession;
+    const std::vector<SfKey>& mObjects;
+
+    PKCS11_SfSession mSession;
+    bool             mSessionInUse;
+};
+
+#endif

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-types.h
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-types.h
@@ -1,0 +1,62 @@
+/* Copyright 2021 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _PKCS11_SF_TYPES_H
+#define _PKCS11_SF_TYPES_H
+
+extern const char* SfTokenLabel;
+extern const char* SfTokenManufacturer;
+extern const char* SfTokenModel;
+extern const char* SfTokenSerialNumber;
+
+extern const char* SfModuleManufacturer;
+extern const char* SfModuleDescription;
+
+extern const char* SfSlotManufacturer;
+extern const char* SfSlotDescription;
+
+extern const char* SfJsonKey_Url;
+extern const char* SfJsonKey_Epwd;
+extern const char* SfJsonKey_PrivateKeyPath;
+extern const char* SfJsonKey_ProjectArray;
+extern const char* SfJsonKey_ProjectName;
+extern const char* SfJsonKey_ProjectType;
+extern const char* SfJsonKey_HashAlgorithm;
+
+enum
+{
+    TokenHardwareVersionMajor = 0,
+    TokenHardwareVersionMinor = 0,
+    TokenFirmwareVersionMajor = 0,
+    TokenFirmwareVersionMinor = 0,
+};
+
+enum
+{
+    ModuleCryptokiVersionMajor = 0,
+    ModuleCryptokiVersionMinor = 0,
+    ModuleLibraryVersionMajor  = 0,
+    ModuleLibraryVersionMinor  = 0,
+};
+
+enum
+{
+    SlotHardwareVersionMajor = 1,
+    SlotHardwareVersionMinor = 0,
+    SlotFirmwareVersionMajor = 1,
+    SlotFirmwareVersionMinor = 0,
+};
+
+#endif

--- a/src/client-c++/sf_utils/include/sf_utils/sf_utils.h
+++ b/src/client-c++/sf_utils/include/sf_utils/sf_utils.h
@@ -1,0 +1,43 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#ifndef _SF_UTILS_H
+#define _SF_UTILS_H
+
+bool GetPassword(char*          dstParm,
+                 const uint64_t dstSizeParm,
+                 uint64_t&      bytesWrittenParm,
+                 const bool     verboseParm);
+
+bool ReadFile(const std::string& filePathParm, std::vector<uint8_t>& dstParm);
+
+bool WriteFile(const std::string& filePathParm, const std::vector<uint8_t>& srcParm);
+
+std::string GetHexStringFromBinary(const std::vector<uint8_t>& binaryParm);
+
+std::vector<uint8_t> GetBinaryFromHexString(const std::string& hexParm);
+
+// Removes any whitespace in the string
+void RemoveAllWhitespace(std::string& strParm);
+
+std::string GetLocalUser();
+
+std::string GetLocalHost();
+
+#endif

--- a/src/client-c++/sf_utils/meson.build
+++ b/src/client-c++/sf_utils/meson.build
@@ -1,0 +1,13 @@
+
+cc = meson.get_compiler('cpp')
+
+sf_utils_lib = static_library(
+    'sf_utils',
+    'sf_utils.cpp',
+    include_directories : 'include'
+)
+
+sf_utils_dep = declare_dependency(
+    include_directories: 'include',
+    link_with: sf_utils_lib
+)

--- a/src/client-c++/sf_utils/sf_utils.cpp
+++ b/src/client-c++/sf_utils/sf_utils.cpp
@@ -1,0 +1,298 @@
+/* Copyright 2020 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <csignal>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdlib.h>
+#include <string>
+#include <termios.h>
+#include <unistd.h>
+#include <vector>
+
+#include "sf_utils/sf_utils.h"
+
+static void SignalHandler(int val)
+{
+    (void)val;
+    struct termios term;
+    tcgetattr(fileno(stdin), &term);
+
+    term.c_lflag |= ECHO;
+    term.c_lflag &= ~ECHONL;
+
+    tcsetattr(fileno(stdin), TCSAFLUSH, &term);
+    exit(-2);
+}
+
+bool GetPassword(char*          dstParm,
+                 const uint64_t dstSizeParm,
+                 uint64_t&      bytesWrittenParm,
+                 const bool     verboseParm)
+{
+    bool sResult = false;
+
+    struct sigaction newSa;
+    newSa.sa_handler = SignalHandler;
+    sigemptyset(&newSa.sa_mask);
+    newSa.sa_flags = SA_RESTART;
+
+    struct sigaction oldSigInt;
+    struct sigaction oldSigTerm;
+    struct sigaction oldSigQuit;
+
+    if(sigaction(SIGINT, &newSa, &oldSigInt) == -1)
+    {
+        if(verboseParm)
+            std::cerr << "ERROR: unable to change SIGINT handler" << std::endl;
+        return false;
+    }
+    if(sigaction(SIGTERM, &newSa, &oldSigTerm) == -1)
+    {
+        if(verboseParm)
+            std::cerr << "ERROR: unable to change SIGTERM handler" << std::endl;
+        return false;
+    }
+    if(sigaction(SIGQUIT, &newSa, &oldSigQuit) == -1)
+    {
+        if(verboseParm)
+            std::cerr << "ERROR: unable to change SIGQUIT handler" << std::endl;
+        return false;
+    }
+
+    struct termios oldTerm, newTerm;
+    tcgetattr(fileno(stdin), &oldTerm);
+
+    newTerm = oldTerm;
+
+    newTerm.c_lflag &= ~ECHO;
+    newTerm.c_lflag |= ECHONL;
+
+    tcsetattr(fileno(stdin), TCSAFLUSH, &newTerm);
+
+    printf("Key Passphrase: ");
+    fflush(stdout);
+
+    char        sChar             = getchar();
+    std::size_t sPassphraseLength = 0;
+
+    while(sChar != '\n' && sChar != '\f' && sChar != '\r')
+    {
+        if(sPassphraseLength < dstSizeParm)
+        {
+            dstParm[sPassphraseLength] = sChar;
+            sPassphraseLength++;
+            sChar = getchar();
+        }
+        else
+        {
+            sResult = false;
+            break;
+        }
+    }
+
+    bytesWrittenParm = sPassphraseLength;
+    sResult          = bytesWrittenParm > 0;
+
+    if(verboseParm && 0 == bytesWrittenParm)
+    {
+        std::cout << "Password was length zero" << std::endl;
+    }
+
+    tcsetattr(fileno(stdin), TCSANOW, &oldTerm);
+
+    if(sigaction(SIGINT, &oldSigInt, NULL) == -1)
+    {
+        if(verboseParm)
+            std::cerr << "ERROR: unable to change SIGINT handler" << std::endl;
+        sResult = false;
+    }
+    if(sigaction(SIGTERM, &oldSigTerm, NULL) == -1)
+    {
+        if(verboseParm)
+            std::cerr << "ERROR: unable to change SIGTERM handler" << std::endl;
+        sResult = false;
+    }
+    if(sigaction(SIGQUIT, &oldSigQuit, NULL) == -1)
+    {
+        if(verboseParm)
+            std::cerr << "ERROR: unable to change SIGQUIT handler" << std::endl;
+        sResult = false;
+    }
+
+    return sResult;
+}
+
+bool ReadFile(const std::string& filePathParm, std::vector<uint8_t>& dstParm)
+{
+    std::ifstream sFile;
+    if(!filePathParm.empty())
+    {
+        sFile.open(filePathParm.c_str(), std::ios::in | std::ios::binary);
+        if(sFile.is_open())
+        {
+            // Get the size of the file
+            sFile.seekg(0, std::ios::end);
+            std::streampos sFileByteSize = sFile.tellg();
+            sFile.seekg(0, std::ios::beg);
+
+            dstParm.reserve(sFileByteSize);
+            dstParm.assign(sFileByteSize, 0);
+
+            sFile.read((char*)dstParm.data(), sFileByteSize);
+            sFile.close();
+
+            return true;
+        }
+        else
+        {
+            std::cout << "Failed to open file " << std::endl;
+        }
+    }
+    else
+    {
+        std::cout << "filename empty" << std::endl;
+    }
+
+    return false;
+}
+
+bool WriteFile(const std::string& filePathParm, const std::vector<uint8_t>& srcParm)
+{
+    std::ofstream sFile;
+    if(!filePathParm.empty() && !srcParm.empty())
+    {
+        sFile.open(filePathParm.c_str(), std::ios::out | std::ios::trunc | std::ios::binary);
+        if(sFile.is_open())
+        {
+            sFile.write((const char*)srcParm.data(), srcParm.size());
+            sFile.close();
+            return true;
+        }
+    }
+    return false;
+}
+
+std::string GetHexStringFromBinary(const std::vector<uint8_t>& binaryParm)
+{
+    std::stringstream ss;
+
+    for(uint64_t sIdx = 0; sIdx < binaryParm.size(); sIdx++)
+    {
+        ss.fill('0');
+        ss.width(2);
+        ss << std::hex << (int)binaryParm[sIdx];
+    }
+
+    std::string sString = ss.str();
+    // std::cout << "BIN -> HEX: " << binaryParm.size() << " -> " << sString.size() << std::endl;
+    return sString;
+}
+
+static uint8_t GetNibbleFromHexChar(const char charParm)
+{
+    switch(charParm)
+    {
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+        return charParm - '0';
+    case 'a':
+    case 'b':
+    case 'c':
+    case 'd':
+    case 'e':
+    case 'f':
+        return charParm - 'a' + 0xA;
+    case 'A':
+    case 'B':
+    case 'C':
+    case 'D':
+    case 'E':
+    case 'F':
+        return charParm - 'A' + 0xA;
+    default:
+        return 0;
+    }
+}
+
+std::vector<uint8_t> GetBinaryFromHexString(const std::string& hexParm)
+{
+    std::vector<uint8_t> sBinary;
+    sBinary.reserve(hexParm.size() / 2);
+
+    for(uint64_t sIdx = 0; !hexParm.empty() && sIdx < hexParm.size() - 1; sIdx += 2)
+    {
+        uint8_t sUpper = GetNibbleFromHexChar(hexParm[sIdx]);
+        uint8_t sLower = GetNibbleFromHexChar(hexParm[sIdx + 1]);
+        sBinary.push_back(sUpper << 4 | sLower);
+    }
+    return sBinary;
+}
+
+// Removes any whitespace in the string
+void RemoveAllWhitespace(std::string& strParm)
+{
+    std::string sNewString;
+    sNewString.reserve(strParm.size());
+
+    for(std::size_t sIdx = 0; sIdx < strParm.size(); sIdx++)
+    {
+        char sChar = strParm[sIdx];
+        if(!isspace(sChar))
+        {
+            sNewString.push_back(sChar);
+        }
+    }
+
+    strParm = sNewString;
+}
+
+std::string GetLocalUser()
+{
+    char sTmpBuffer[1024];
+
+    int rc = getlogin_r(sTmpBuffer, sizeof(sTmpBuffer));
+    if(0 == rc)
+    {
+        return std::string(sTmpBuffer);
+    }
+    else
+    {
+        return "UnknownUser";
+    }
+}
+
+std::string GetLocalHost()
+{
+    char sTmpBuffer[1024];
+    int  rc = gethostname(sTmpBuffer, sizeof(sTmpBuffer));
+    if(0 == rc)
+    {
+        return std::string(sTmpBuffer);
+    }
+    else
+    {
+        return "UnknownHost";
+    }
+}


### PR DESCRIPTION
Some signing tooling, such as mkimage,  does not support arbitrary
signing programs (which is effectively what sf_client is). However
mkimage does support openssl engines. By wrapping sf_client
functionality in a pkcs11 module, it can be loaded into a pkcs11 openssl
engine, allowing sf_client usage by mkimage.

This is far from a feature-rich pkcs11 module, it is written to only
provide access to the single signing mechanism (it is hardcoded to a
specific hash algorithm).