### PR TITLE
Fix polling issue where retries never actually executed the read

### DIFF
--- a/src/client-c++/cli_main.cpp
+++ b/src/client-c++/cli_main.cpp
@@ -412,7 +412,11 @@ int main(int argc, char** argv)
     if(sIsSuccess)
     {
         sf_client::rc sRc = sf_client::sendCommandV1(sSession, sSfArgsV1, sSfResponseV1);
-        sIsSuccess        = sf_client::success == sRc;
+        if(sf_client::success != sRc)
+        {
+           sIsSuccess = false;
+           std::cout << "Send Command Failed with rc: " << (int)sRc << std::endl;
+        }
     }
 
     if(sIsSuccess)
@@ -441,6 +445,8 @@ int main(int argc, char** argv)
 
     if(sIsSuccess)
         std::cout << "DONE" << std::endl;
+    else
+        std::cout << "FAILED" << std::endl;
 
     return sIsSuccess ? 0 : -1;
 }

--- a/src/client-c++/sf_client_lib/sf_curl.cpp
+++ b/src/client-c++/sf_client_lib/sf_curl.cpp
@@ -325,8 +325,13 @@ sf_client::rc sf_client::sendAndReceiveCommand(Curl_Session&      curlSessionPar
     std::size_t sNumPolls = 0;
     do
     {
-        sleep(1);
         sNumPolls++;
+
+        if(CURLE_REMOTE_FILE_NOT_FOUND == sRc)
+        {
+            // Reset the return code so that READ_FROM_SERVER will execute
+            sRc = CURLE_OK;
+        }
 
         std::string sResponseGo;
         READ_FROM_SERVER(sRc, curlSessionParm, sSessionFileNames.mResponseFileGo, sResponseGo);


### PR DESCRIPTION
READ_FROM_SERVER will check that the return code is CURLE_OK before attempting to read. Since return code is CURLE_REMOTE_FILE_NOT_FOUND after the first iteration fails the read was never attempted again.