### PR TITLE
Fix compiler warnings for openssl 3.0 and curl 7.85

### DIFF
--- a/src/client-c++/sf_client_lib/sf_curl.cpp
+++ b/src/client-c++/sf_client_lib/sf_curl.cpp
@@ -261,7 +261,11 @@ sf_client::rc sf_client::curlConnectToServer(const Curl_ServerInfo& serverInfoPa
             sRc, curlSessionParm, CURLOPT_SSH_PUBLIC_KEYFILE, serverInfoParm.mPublicKeyPath.c_str());
 
     SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_URL, serverInfoParm.mUrl.c_str());
+#if LIBCURL_VERSION_NUM >= 0x075500
+    SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_PROTOCOLS_STR, "sftp");
+#else
     SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_PROTOCOLS, CURLPROTO_SFTP);
+#endif
 
     SET_CURL_OPTION(sRc, curlSessionParm, CURLOPT_CONNECT_ONLY, 1L);
 

--- a/src/client-c++/sf_pkcs11/src/pkcs11-sf-slot.cpp
+++ b/src/client-c++/sf_pkcs11/src/pkcs11-sf-slot.cpp
@@ -50,13 +50,13 @@ CK_FLAGS PKCS11_SfSlot::getFlags() const
 void PKCS11_SfSlot::getDescription(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const
 {
     memset(dstParm, ' ', sizeParm);
-    memcpy(dstParm, mDescription.c_str(), std::min(sizeParm, mDescription.size()));
+    memcpy(dstParm, mDescription.c_str(), std::min(sizeParm, static_cast<uint64_t>(mDescription.size())));
 }
 
 void PKCS11_SfSlot::getManufacturerId(CK_UTF8CHAR* dstParm, uint64_t sizeParm) const
 {
     memset(dstParm, ' ', sizeParm);
-    memcpy(dstParm, mManufacturerId.c_str(), std::min(sizeParm, mManufacturerId.size()));
+    memcpy(dstParm, mManufacturerId.c_str(), std::min(sizeParm, static_cast<uint64_t>(mManufacturerId.size())));
 }
 
 CK_VERSION PKCS11_SfSlot::getHardwareVersion() const { return mHardwareVersion; }

--- a/src/client-c++/sf_utils/sf_utils.cpp
+++ b/src/client-c++/sf_utils/sf_utils.cpp
@@ -87,7 +87,7 @@ bool GetPassword(char*          dstParm,
     fflush(stdout);
 
     char        sChar             = getchar();
-    std::size_t sPassphraseLength = 0;
+    uint64_t sPassphraseLength = 0;
 
     while(sChar != '\n' && sChar != '\f' && sChar != '\r')
     {

--- a/src/client/pscp_sftp.c
+++ b/src/client/pscp_sftp.c
@@ -96,7 +96,11 @@ struct pscp_sftp_session*  startSftpSession(const char * sftp_url, const char * 
         }
     }
 
+#if LIBCURL_VERSION_NUM >= 0x075500
+    if(status == CURLE_OK) status = curl_easy_setopt(sftp->curl, CURLOPT_PROTOCOLS_STR, "sftp");
+#else
     if(status == CURLE_OK) status = curl_easy_setopt(sftp->curl, CURLOPT_PROTOCOLS, CURLPROTO_SFTP);
+#endif
     if(status == CURLE_OK) status = curl_easy_setopt(sftp->curl, CURLOPT_SSH_PRIVATE_KEYFILE, privateKeyPath);
 
     if(status == CURLE_OK)


### PR DESCRIPTION
The new compiler gcc-13 is flagging warnings in addition to openssl 3.0
and curl 7.85.
Fix the compiler warnings such as std::min requiring the same parameter
types.
Fix the openssl warnings by replacing the deprecated APIs if version is
3.0 or above.
Fix the curl warnings by replacing the deprecated APIs if version is
7.85 or above.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>