### PR TITLE
Revert "Fix compilation with meson"

### DIFF
--- a/src/client-c++/meson.build
+++ b/src/client-c++/meson.build
@@ -25,8 +25,6 @@ git_version = vcs_tag(command: ['git', 'rev-parse', '--short', 'HEAD'],
                       output : 'git_hash.h',
                       replace_string: '@GIT_VERSION@')
 
-include_directories('build')
-
 if( get_option('verbose') == true )
   add_global_arguments('-DDEBUG', language: 'cpp')
 endif


### PR DESCRIPTION
This reverts commit 33db565196660dd0a4ca4fc0f788420c6276aa99.

"build" is not a special directory in meson. It is legal to provide an alternate path to the setup command:
`meson setup otherdir`

By including a "build" directory in the meson config, the reverted commit breaks the setup step for any projects that use a different directory name for their artifacts.