### PR TITLE
client-c++: add generated file dependency

### DIFF
--- a/src/client-c++/meson.build
+++ b/src/client-c++/meson.build
@@ -56,6 +56,7 @@ endif
 executable(
     'sf_client',
     'cli_main.cpp',
+    git_version,
     dependencies: [
         sf_client_dep
     ],


### PR DESCRIPTION
When building this in the bitbake env (which runs everything it can in parallel), it hit an issue where the generated h file was not available when trying to build the application that includes it.

Fix this issue by ensuring the application is not built until the header file is generated.